### PR TITLE
fix: resolve grype command not found in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,9 +210,11 @@ jobs:
 
     - name: Install Grype
       uses: anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
+      id: grype
 
     - name: Install Syft
       uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+      id: syft
 
     - name: Scan binaries with Grype
       run: |
@@ -226,8 +228,8 @@ jobs:
         for binary in binaries/"${PREFIX}"-*; do
           if [ -f "$binary" ] && [[ ! "$binary" == *.txt ]]; then
             echo "Scanning: $binary"
-            grype "$binary" --output json --file "${binary}-grype-report.json" || true
-            grype "$binary" --output table || true
+            "${{ steps.grype.outputs.cmd }}" "$binary" --output json --file "${binary}-grype-report.json" || true
+            "${{ steps.grype.outputs.cmd }}" "$binary" --output table || true
             echo "---"
           fi
         done
@@ -244,8 +246,8 @@ jobs:
         for binary in binaries/"${PREFIX}"-*; do
           if [ -f "$binary" ] && [[ ! "$binary" == *.txt ]]; then
             echo "Generating SBOM for: $binary"
-            syft "$binary" --output cyclonedx-json --file "${binary}-sbom.json" || true
-            syft "$binary" --output table || true
+            "${{ steps.syft.outputs.cmd }}" "$binary" --output cyclonedx-json --file "${binary}-sbom.json" || true
+            "${{ steps.syft.outputs.cmd }}" "$binary" --output table || true
             echo "---"
           fi
         done


### PR DESCRIPTION
## Summary
- Fixed the 'grype: command not found' error in the binary security scan job
- Added id attributes to grype and syft installation steps  
- Updated scan commands to use the output paths from the download actions

## Problem
The anchore download actions (download-grype and download-syft) only download the binaries but don't add them to the system PATH. This caused the workflow to fail when trying to execute the grype and syft commands.

## Solution
Use the 'cmd' output from the download actions which provides the absolute path to the executables.

Fixes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized resolution of security scanning tools in CI, improving reliability of vulnerability scans and SBOM generation across platforms and jobs.
  * Centralized configuration reduces flakiness from missing binaries and makes builds more consistent.
  * Improves maintainability of the build pipeline without impacting product behavior.
  * No user-facing changes; functionality and interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->