### PR TITLE
Implement database-side pagination for scopes + CLI pagination wiring

### DIFF
--- a/contexts/event-store/infrastructure/src/test/kotlin/io/github/kamiazya/scopes/eventstore/infrastructure/repository/SqlDelightEventRepositoryTest.kt
+++ b/contexts/event-store/infrastructure/src/test/kotlin/io/github/kamiazya/scopes/eventstore/infrastructure/repository/SqlDelightEventRepositoryTest.kt
@@ -249,7 +249,7 @@ class SqlDelightEventRepositoryTest :
                     do {
                         timestampBetween = Clock.System.now()
                     } while (timestampBetween <= firstStoredEvent.metadata.storedAt)
-                    
+
                     // Wait again to ensure the second event is stored after timestampBetween
                     var secondEventTime: Instant
                     do {
@@ -418,7 +418,7 @@ class SqlDelightEventRepositoryTest :
                     do {
                         timestampBetween = Clock.System.now()
                     } while (timestampBetween <= oldStoredEvent.metadata.storedAt)
-                    
+
                     // Wait again to ensure the recent event is stored after timestampBetween
                     var recentEventTime: Instant
                     do {

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/dto/PagedResult.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/dto/PagedResult.kt
@@ -1,0 +1,6 @@
+package io.github.kamiazya.scopes.scopemanagement.application.dto
+
+/**
+ * Generic paged result for application layer.
+ */
+data class PagedResult<T>(val items: List<T>, val totalCount: Int, val offset: Int, val limit: Int)

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
@@ -32,12 +32,14 @@ class GetChildrenHandler(private val scopeRepository: ScopeRepository, private v
 
         // Get children from repository with database-side pagination
         val children = scopeRepository.findByParentId(parentId, input.offset, input.limit).bind()
+        val totalCount = scopeRepository.countByParentId(parentId).bind()
 
         logger.debug(
             "Found children",
             mapOf(
                 "parentId" to (parentId?.value ?: "root"),
                 "pageSize" to children.size.toString(),
+                "totalCount" to totalCount.toString(),
             ),
         )
 

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
@@ -30,8 +30,8 @@ class GetChildrenHandler(private val scopeRepository: ScopeRepository, private v
             ScopeId.create(parentIdString).bind()
         }
 
-        // Get children from repository
-        val children = scopeRepository.findByParentId(parentId).bind()
+        // Get children from repository with database-side pagination
+        val children = scopeRepository.findByParentId(parentId, input.offset, input.limit).bind()
 
         logger.debug(
             "Found children",
@@ -41,14 +41,8 @@ class GetChildrenHandler(private val scopeRepository: ScopeRepository, private v
             ),
         )
 
-        // Apply pagination
-        val paginatedChildren = children
-            .sortedBy { it.createdAt } // Sort by creation time
-            .drop(input.offset)
-            .take(input.limit)
-
         // Convert to DTOs
-        val result = paginatedChildren.map { scope ->
+        val result = children.map { scope ->
             ScopeMapper.toDto(scope)
         }
 

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
@@ -37,14 +37,12 @@ class GetChildrenHandler(private val scopeRepository: ScopeRepository, private v
             "Found children",
             mapOf(
                 "parentId" to (parentId?.value ?: "root"),
-                "totalCount" to children.size.toString(),
+                "pageSize" to children.size.toString(),
             ),
         )
 
         // Convert to DTOs
-        val result = children.map { scope ->
-            ScopeMapper.toDto(scope)
-        }
+        val result = children.map(ScopeMapper::toDto)
 
         logger.info(
             "Retrieved children successfully",

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetChildrenHandler.kt
@@ -3,6 +3,7 @@ package io.github.kamiazya.scopes.scopemanagement.application.handler
 import arrow.core.Either
 import arrow.core.raise.either
 import io.github.kamiazya.scopes.platform.observability.logging.Logger
+import io.github.kamiazya.scopes.scopemanagement.application.dto.PagedResult
 import io.github.kamiazya.scopes.scopemanagement.application.dto.ScopeDto
 import io.github.kamiazya.scopes.scopemanagement.application.mapper.ScopeMapper
 import io.github.kamiazya.scopes.scopemanagement.application.query.GetChildren
@@ -14,9 +15,9 @@ import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.ScopeId
 /**
  * Handler for getting children of a scope.
  */
-class GetChildrenHandler(private val scopeRepository: ScopeRepository, private val logger: Logger) : UseCase<GetChildren, ScopesError, List<ScopeDto>> {
+class GetChildrenHandler(private val scopeRepository: ScopeRepository, private val logger: Logger) : UseCase<GetChildren, ScopesError, PagedResult<ScopeDto>> {
 
-    override suspend operator fun invoke(input: GetChildren): Either<ScopesError, List<ScopeDto>> = either {
+    override suspend operator fun invoke(input: GetChildren): Either<ScopesError, PagedResult<ScopeDto>> = either {
         val contextData = mapOf(
             "parentId" to (input.parentId ?: "root"),
             "offset" to input.offset.toString(),
@@ -54,7 +55,12 @@ class GetChildrenHandler(private val scopeRepository: ScopeRepository, private v
             ),
         )
 
-        result
+        PagedResult(
+            items = result,
+            totalCount = totalCount,
+            offset = input.offset,
+            limit = input.limit,
+        )
     }.onLeft { error ->
         logger.error(
             "Failed to get children",

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
@@ -26,11 +26,13 @@ class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private
 
         // Get root scopes (parentId = null) with database-side pagination
         val rootScopes = scopeRepository.findByParentId(null, input.offset, input.limit).bind()
+        val totalCount = scopeRepository.countByParentId(null).bind()
 
         logger.debug(
             "Found root scopes",
             mapOf(
                 "pageSize" to rootScopes.size.toString(),
+                "totalCount" to totalCount.toString(),
             ),
         )
 

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
@@ -3,6 +3,7 @@ package io.github.kamiazya.scopes.scopemanagement.application.handler
 import arrow.core.Either
 import arrow.core.raise.either
 import io.github.kamiazya.scopes.platform.observability.logging.Logger
+import io.github.kamiazya.scopes.scopemanagement.application.dto.PagedResult
 import io.github.kamiazya.scopes.scopemanagement.application.dto.ScopeDto
 import io.github.kamiazya.scopes.scopemanagement.application.mapper.ScopeMapper
 import io.github.kamiazya.scopes.scopemanagement.application.query.GetRootScopes
@@ -13,9 +14,10 @@ import io.github.kamiazya.scopes.scopemanagement.domain.repository.ScopeReposito
 /**
  * Handler for getting root scopes (scopes without parent).
  */
-class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private val logger: Logger) : UseCase<GetRootScopes, ScopesError, List<ScopeDto>> {
+class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private val logger: Logger) :
+    UseCase<GetRootScopes, ScopesError, PagedResult<ScopeDto>> {
 
-    override suspend operator fun invoke(input: GetRootScopes): Either<ScopesError, List<ScopeDto>> = either {
+    override suspend operator fun invoke(input: GetRootScopes): Either<ScopesError, PagedResult<ScopeDto>> = either {
         logger.debug(
             "Getting root scopes",
             mapOf(
@@ -46,7 +48,12 @@ class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private
             ),
         )
 
-        result
+        PagedResult(
+            items = result,
+            totalCount = totalCount,
+            offset = input.offset,
+            limit = input.limit,
+        )
     }.onLeft { error ->
         logger.error(
             "Failed to get root scopes",

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
@@ -30,14 +30,12 @@ class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private
         logger.debug(
             "Found root scopes",
             mapOf(
-                "totalCount" to rootScopes.size.toString(),
+                "pageSize" to rootScopes.size.toString(),
             ),
         )
 
         // Convert to DTOs
-        val result = rootScopes.map { scope ->
-            ScopeMapper.toDto(scope)
-        }
+        val result = rootScopes.map(ScopeMapper::toDto)
 
         logger.info(
             "Retrieved root scopes successfully",

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/handler/GetRootScopesHandler.kt
@@ -24,8 +24,8 @@ class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private
             ),
         )
 
-        // Get root scopes (parentId = null)
-        val rootScopes = scopeRepository.findByParentId(null).bind()
+        // Get root scopes (parentId = null) with database-side pagination
+        val rootScopes = scopeRepository.findByParentId(null, input.offset, input.limit).bind()
 
         logger.debug(
             "Found root scopes",
@@ -34,14 +34,8 @@ class GetRootScopesHandler(private val scopeRepository: ScopeRepository, private
             ),
         )
 
-        // Apply pagination
-        val paginatedScopes = rootScopes
-            .sortedBy { it.createdAt } // Sort by creation time
-            .drop(input.offset)
-            .take(input.limit)
-
         // Convert to DTOs
-        val result = paginatedScopes.map { scope ->
+        val result = rootScopes.map { scope ->
             ScopeMapper.toDto(scope)
         }
 

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
@@ -90,6 +90,12 @@ interface ScopeRepository {
     suspend fun countChildrenOf(parentId: ScopeId): Either<PersistenceError, Int>
 
     /**
+     * Count scopes by parent id. When parentId is null, counts root scopes.
+     * Useful for pagination total counts.
+     */
+    suspend fun countByParentId(parentId: ScopeId?): Either<PersistenceError, Int>
+
+    /**
      * Find all descendants of a scope recursively.
      * Used for hierarchy operations.
      */

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
@@ -31,6 +31,7 @@ interface ScopeRepository {
     /**
      * Find scopes by parent ID.
      */
+    @Deprecated("Use paginated overload to avoid full scans; will be removed in a future release.")
     suspend fun findByParentId(parentId: ScopeId?): Either<PersistenceError, List<Scope>>
 
     /**

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
@@ -34,6 +34,13 @@ interface ScopeRepository {
     suspend fun findByParentId(parentId: ScopeId?): Either<PersistenceError, List<Scope>>
 
     /**
+     * Find scopes by parent ID with pagination.
+     * Results are ordered by creation time ascending to provide stable paging.
+     * When parentId is null, returns root scopes.
+     */
+    suspend fun findByParentId(parentId: ScopeId?, offset: Int, limit: Int): Either<PersistenceError, List<Scope>>
+
+    /**
      * Check if a scope exists.
      */
     suspend fun existsById(id: ScopeId): Either<PersistenceError, Boolean>

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementPortAdapter.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementPortAdapter.kt
@@ -14,6 +14,7 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractE
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetChildrenQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeByAliasQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeQuery
+import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListAliasesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasInfo
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult
@@ -165,6 +166,8 @@ class ScopeManagementPortAdapter(
     override suspend fun getChildren(query: GetChildrenQuery): Either<ScopeContractError, List<ScopeResult>> = getChildrenHandler(
         GetChildren(
             parentId = query.parentId,
+            offset = query.offset,
+            limit = query.limit,
         ),
     ).mapLeft { error ->
         errorMapper.mapToContractError(error)
@@ -184,8 +187,11 @@ class ScopeManagementPortAdapter(
         }
     }
 
-    override suspend fun getRootScopes(): Either<ScopeContractError, List<ScopeResult>> = getRootScopesHandler(
-        GetRootScopes(),
+    override suspend fun getRootScopes(query: GetRootScopesQuery): Either<ScopeContractError, List<ScopeResult>> = getRootScopesHandler(
+        GetRootScopes(
+            offset = query.offset,
+            limit = query.limit,
+        ),
     ).mapLeft { error ->
         errorMapper.mapToContractError(error)
     }.map { scopeDtos ->

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementPortAdapter.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementPortAdapter.kt
@@ -12,9 +12,9 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.commands.SetCanonical
 import io.github.kamiazya.scopes.contracts.scopemanagement.commands.UpdateScopeCommand
 import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractError
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetChildrenQuery
+import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeByAliasQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeQuery
-import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListAliasesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasInfo
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementPortAdapter.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementPortAdapter.kt
@@ -168,7 +168,9 @@ class ScopeManagementPortAdapter(
         )
     }
 
-    override suspend fun getChildren(query: GetChildrenQuery): Either<ScopeContractError, List<ScopeResult>> = getChildrenHandler(
+    override suspend fun getChildren(
+        query: GetChildrenQuery,
+    ): Either<ScopeContractError, io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult> = getChildrenHandler(
         GetChildren(
             parentId = query.parentId,
             offset = query.offset,
@@ -176,43 +178,55 @@ class ScopeManagementPortAdapter(
         ),
     ).mapLeft { error ->
         errorMapper.mapToContractError(error)
-    }.map { scopeDtos ->
-        scopeDtos.map { scopeDto ->
-            ScopeResult(
-                id = scopeDto.id,
-                title = scopeDto.title,
-                description = scopeDto.description,
-                parentId = scopeDto.parentId,
-                canonicalAlias = scopeDto.canonicalAlias ?: scopeDto.id,
-                createdAt = scopeDto.createdAt,
-                updatedAt = scopeDto.updatedAt,
-                isArchived = false, // TODO: Implement archive status when available in domain
-                aspects = scopeDto.aspects,
-            )
-        }
+    }.map { paged ->
+        io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult(
+            scopes = paged.items.map { scopeDto ->
+                ScopeResult(
+                    id = scopeDto.id,
+                    title = scopeDto.title,
+                    description = scopeDto.description,
+                    parentId = scopeDto.parentId,
+                    canonicalAlias = scopeDto.canonicalAlias ?: scopeDto.id,
+                    createdAt = scopeDto.createdAt,
+                    updatedAt = scopeDto.updatedAt,
+                    isArchived = false, // TODO: Implement archive status when available in domain
+                    aspects = scopeDto.aspects,
+                )
+            },
+            totalCount = paged.totalCount,
+            offset = paged.offset,
+            limit = paged.limit,
+        )
     }
 
-    override suspend fun getRootScopes(query: GetRootScopesQuery): Either<ScopeContractError, List<ScopeResult>> = getRootScopesHandler(
+    override suspend fun getRootScopes(
+        query: GetRootScopesQuery,
+    ): Either<ScopeContractError, io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult> = getRootScopesHandler(
         GetRootScopes(
             offset = query.offset,
             limit = query.limit,
         ),
     ).mapLeft { error ->
         errorMapper.mapToContractError(error)
-    }.map { scopeDtos ->
-        scopeDtos.map { scopeDto ->
-            ScopeResult(
-                id = scopeDto.id,
-                title = scopeDto.title,
-                description = scopeDto.description,
-                parentId = scopeDto.parentId,
-                canonicalAlias = scopeDto.canonicalAlias ?: scopeDto.id,
-                createdAt = scopeDto.createdAt,
-                updatedAt = scopeDto.updatedAt,
-                isArchived = false, // TODO: Implement archive status when available in domain
-                aspects = scopeDto.aspects,
-            )
-        }
+    }.map { paged ->
+        io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult(
+            scopes = paged.items.map { scopeDto ->
+                ScopeResult(
+                    id = scopeDto.id,
+                    title = scopeDto.title,
+                    description = scopeDto.description,
+                    parentId = scopeDto.parentId,
+                    canonicalAlias = scopeDto.canonicalAlias ?: scopeDto.id,
+                    createdAt = scopeDto.createdAt,
+                    updatedAt = scopeDto.updatedAt,
+                    isArchived = false, // TODO: Implement archive status when available in domain
+                    aspects = scopeDto.aspects,
+                )
+            },
+            totalCount = paged.totalCount,
+            offset = paged.offset,
+            limit = paged.limit,
+        )
     }
 
     override suspend fun getScopeByAlias(query: GetScopeByAliasQuery): Either<ScopeContractError, ScopeResult> = either {

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/InMemoryScopeRepository.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/InMemoryScopeRepository.kt
@@ -91,6 +91,22 @@ open class InMemoryScopeRepository : ScopeRepository {
         }
     }
 
+    override suspend fun findByParentId(parentId: ScopeId?, offset: Int, limit: Int): Either<PersistenceError, List<Scope>> = either {
+        mutex.withLock {
+            try {
+                scopes.values
+                    .asSequence()
+                    .filter { it.parentId == parentId }
+                    .sortedBy { it.createdAt }
+                    .drop(offset)
+                    .take(limit)
+                    .toList()
+            } catch (e: Exception) {
+                raise(PersistenceError.StorageUnavailable(currentTimestamp(), "findByParentId(offset,limit)", e))
+            }
+        }
+    }
+
     override suspend fun deleteById(id: ScopeId): Either<PersistenceError, Unit> = either {
         mutex.withLock {
             try {

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/InMemoryScopeRepository.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/InMemoryScopeRepository.kt
@@ -181,6 +181,16 @@ open class InMemoryScopeRepository : ScopeRepository {
         }
     }
 
+    override suspend fun countByParentId(parentId: ScopeId?): Either<PersistenceError, Int> = either {
+        mutex.withLock {
+            try {
+                scopes.values.count { it.parentId == parentId }
+            } catch (e: Exception) {
+                raise(PersistenceError.StorageUnavailable(currentTimestamp(), "countByParentId", e))
+            }
+        }
+    }
+
     override suspend fun findAll(offset: Int, limit: Int): Either<PersistenceError, List<Scope>> = either {
         mutex.withLock {
             try {

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/SqlDelightScopeRepository.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/SqlDelightScopeRepository.kt
@@ -117,6 +117,24 @@ class SqlDelightScopeRepository(private val database: ScopeManagementDatabase) :
         }
     }
 
+    override suspend fun findByParentId(parentId: ScopeId?, offset: Int, limit: Int): Either<PersistenceError, List<Scope>> = withContext(Dispatchers.IO) {
+        try {
+            val rows = if (parentId != null) {
+                database.scopeQueries.findScopesByParentIdPaged(parentId.value, limit.toLong(), offset.toLong()).executeAsList()
+            } else {
+                database.scopeQueries.findRootScopesPaged(limit.toLong(), offset.toLong()).executeAsList()
+            }
+
+            rows.map { rowToScope(it) }.right()
+        } catch (e: Exception) {
+            PersistenceError.StorageUnavailable(
+                occurredAt = Clock.System.now(),
+                operation = "findByParentId(offset,limit)",
+                cause = e,
+            ).left()
+        }
+    }
+
     override suspend fun existsById(id: ScopeId): Either<PersistenceError, Boolean> = withContext(Dispatchers.IO) {
         try {
             val exists = database.scopeQueries.existsById(id.value).executeAsOne()

--- a/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/Scope.sq
+++ b/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/Scope.sq
@@ -66,6 +66,17 @@ WHERE parent_id IS NULL
 ORDER BY created_at ASC, id ASC
 LIMIT ? OFFSET ?;
 
+-- Count helpers for pagination
+countScopesByParentId:
+SELECT COUNT(*) AS count
+FROM scopes
+WHERE parent_id = ?;
+
+countRootScopes:
+SELECT COUNT(*) AS count
+FROM scopes
+WHERE parent_id IS NULL;
+
 -- Check if scope exists
 existsById:
 SELECT COUNT(*) > 0 AS result

--- a/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/Scope.sq
+++ b/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/Scope.sq
@@ -39,12 +39,28 @@ FROM scopes
 WHERE parent_id = ?
 ORDER BY created_at DESC;
 
+-- Find scopes by parent ID with pagination (ascending by creation time)
+findScopesByParentIdPaged:
+SELECT *
+FROM scopes
+WHERE parent_id = ?
+ORDER BY created_at ASC
+LIMIT ? OFFSET ?;
+
 -- Find root scopes
 findRootScopes:
 SELECT *
 FROM scopes
 WHERE parent_id IS NULL
 ORDER BY created_at DESC;
+
+-- Find root scopes with pagination (ascending by creation time)
+findRootScopesPaged:
+SELECT *
+FROM scopes
+WHERE parent_id IS NULL
+ORDER BY created_at ASC
+LIMIT ? OFFSET ?;
 
 -- Check if scope exists
 existsById:

--- a/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/Scope.sq
+++ b/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/Scope.sq
@@ -14,6 +14,10 @@ CREATE INDEX IF NOT EXISTS idx_scopes_parent_id ON scopes(parent_id);
 CREATE INDEX IF NOT EXISTS idx_scopes_created_at ON scopes(created_at);
 CREATE INDEX IF NOT EXISTS idx_scopes_updated_at ON scopes(updated_at);
 CREATE INDEX IF NOT EXISTS idx_scopes_title_parent ON scopes(title, parent_id);
+-- Optimizes paged queries by enabling index-order scan
+CREATE INDEX IF NOT EXISTS idx_scopes_parent_created ON scopes(parent_id, created_at, id);
+-- Optional but helpful for root scans (partial index)
+CREATE INDEX IF NOT EXISTS idx_scopes_root_created ON scopes(created_at, id) WHERE parent_id IS NULL;
 
 -- Insert scope
 insertScope:
@@ -37,14 +41,14 @@ findScopesByParentId:
 SELECT *
 FROM scopes
 WHERE parent_id = ?
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC;
 
 -- Find scopes by parent ID with pagination (ascending by creation time)
 findScopesByParentIdPaged:
 SELECT *
 FROM scopes
 WHERE parent_id = ?
-ORDER BY created_at ASC
+ORDER BY created_at ASC, id ASC
 LIMIT ? OFFSET ?;
 
 -- Find root scopes
@@ -52,14 +56,14 @@ findRootScopes:
 SELECT *
 FROM scopes
 WHERE parent_id IS NULL
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC;
 
 -- Find root scopes with pagination (ascending by creation time)
 findRootScopesPaged:
 SELECT *
 FROM scopes
 WHERE parent_id IS NULL
-ORDER BY created_at ASC
+ORDER BY created_at ASC, id ASC
 LIMIT ? OFFSET ?;
 
 -- Check if scope exists
@@ -107,4 +111,4 @@ WHERE id = ?;
 selectAll:
 SELECT *
 FROM scopes
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC;

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/ScopeManagementPort.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/ScopeManagementPort.kt
@@ -12,6 +12,7 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractE
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetChildrenQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeByAliasQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeQuery
+import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListAliasesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.CreateScopeResult
@@ -62,7 +63,7 @@ public interface ScopeManagementPort {
      * Retrieves all root scopes (scopes without parent).
      * @return Either an error or the list of root scopes
      */
-    public suspend fun getRootScopes(): Either<ScopeContractError, List<ScopeResult>>
+    public suspend fun getRootScopes(query: GetRootScopesQuery): Either<ScopeContractError, List<ScopeResult>>
 
     /**
      * Retrieves a scope by its alias name.

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/ScopeManagementPort.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/ScopeManagementPort.kt
@@ -10,9 +10,9 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.commands.SetCanonical
 import io.github.kamiazya.scopes.contracts.scopemanagement.commands.UpdateScopeCommand
 import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractError
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetChildrenQuery
+import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeByAliasQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeQuery
-import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListAliasesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.CreateScopeResult
@@ -60,8 +60,9 @@ public interface ScopeManagementPort {
     public suspend fun getChildren(query: GetChildrenQuery): Either<ScopeContractError, List<ScopeResult>>
 
     /**
-     * Retrieves all root scopes (scopes without parent).
-     * @return Either an error or the list of root scopes
+     * Retrieves root scopes (scopes without parent) with deterministic ordering.
+     * Pagination is controlled by the query (offset ≥ 0, limit > 0).
+     * @return Either an error or the list of root scopes for the requested page
      */
     public suspend fun getRootScopes(query: GetRootScopesQuery): Either<ScopeContractError, List<ScopeResult>>
 

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/ScopeManagementPort.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/ScopeManagementPort.kt
@@ -59,14 +59,18 @@ public interface ScopeManagementPort {
      * @param query The query containing the parent scope ID
      * @return Either an error or the list of child scopes
      */
-    public suspend fun getChildren(query: GetChildrenQuery): Either<ScopeContractError, List<ScopeResult>>
+    public suspend fun getChildren(
+        query: GetChildrenQuery,
+    ): Either<ScopeContractError, io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult>
 
     /**
      * Retrieves root scopes (scopes without parent) with deterministic ordering.
      * Pagination is controlled by the query (offset ≥ 0, limit > 0).
      * @return Either an error or the list of root scopes for the requested page
      */
-    public suspend fun getRootScopes(query: GetRootScopesQuery): Either<ScopeContractError, List<ScopeResult>>
+    public suspend fun getRootScopes(
+        query: GetRootScopesQuery,
+    ): Either<ScopeContractError, io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult>
 
     /**
      * Retrieves a scope by its alias name.

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetChildrenQuery.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetChildrenQuery.kt
@@ -6,4 +6,8 @@ package io.github.kamiazya.scopes.contracts.scopemanagement.queries
  * This is a minimal contract for retrieving child scopes that contains only
  * the essential fields needed by external consumers.
  */
-public data class GetChildrenQuery(public val parentId: String)
+public data class GetChildrenQuery(
+    public val parentId: String,
+    public val offset: Int = 0,
+    public val limit: Int = 100,
+)

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetChildrenQuery.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetChildrenQuery.kt
@@ -6,8 +6,4 @@ package io.github.kamiazya.scopes.contracts.scopemanagement.queries
  * This is a minimal contract for retrieving child scopes that contains only
  * the essential fields needed by external consumers.
  */
-public data class GetChildrenQuery(
-    public val parentId: String,
-    public val offset: Int = 0,
-    public val limit: Int = 100,
-)
+public data class GetChildrenQuery(public val parentId: String, public val offset: Int = 0, public val limit: Int = 100)

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetRootScopesQuery.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetRootScopesQuery.kt
@@ -3,8 +3,4 @@ package io.github.kamiazya.scopes.contracts.scopemanagement.queries
 /**
  * Query for retrieving root scopes (no parent).
  */
-public data class GetRootScopesQuery(
-    public val offset: Int = 0,
-    public val limit: Int = 100,
-)
-
+public data class GetRootScopesQuery(public val offset: Int = 0, public val limit: Int = 100)

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetRootScopesQuery.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/queries/GetRootScopesQuery.kt
@@ -1,0 +1,10 @@
+package io.github.kamiazya.scopes.contracts.scopemanagement.queries
+
+/**
+ * Query for retrieving root scopes (no parent).
+ */
+public data class GetRootScopesQuery(
+    public val offset: Int = 0,
+    public val limit: Int = 100,
+)
+

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/results/ScopeListResult.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/results/ScopeListResult.kt
@@ -1,0 +1,6 @@
+package io.github.kamiazya.scopes.contracts.scopemanagement.results
+
+/**
+ * Paginated result containing a list of scopes with total count and window info.
+ */
+public data class ScopeListResult(public val scopes: List<ScopeResult>, public val totalCount: Int, public val offset: Int, public val limit: Int)

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/adapters/ScopeCommandAdapter.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/adapters/ScopeCommandAdapter.kt
@@ -9,6 +9,7 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractE
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetChildrenQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListAliasesQuery
+import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.CreateScopeResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeResult
@@ -109,15 +110,16 @@ class ScopeCommandAdapter(
     /**
      * Lists child scopes
      */
-    suspend fun listChildren(parentId: String): Either<ScopeContractError, List<ScopeResult>> {
-        val query = GetChildrenQuery(parentId = parentId)
+    suspend fun listChildren(parentId: String, offset: Int, limit: Int): Either<ScopeContractError, List<ScopeResult>> {
+        val query = GetChildrenQuery(parentId = parentId, offset = offset, limit = limit)
         return scopeManagementPort.getChildren(query)
     }
 
     /**
      * Lists root scopes
      */
-    suspend fun listRootScopes(): Either<ScopeContractError, List<ScopeResult>> = scopeManagementPort.getRootScopes()
+    suspend fun listRootScopes(offset: Int, limit: Int): Either<ScopeContractError, List<ScopeResult>> =
+        scopeManagementPort.getRootScopes(GetRootScopesQuery(offset = offset, limit = limit))
 
     /**
      * Lists all aliases for a specific scope

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/adapters/ScopeCommandAdapter.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/adapters/ScopeCommandAdapter.kt
@@ -7,9 +7,9 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.commands.DeleteScopeC
 import io.github.kamiazya.scopes.contracts.scopemanagement.commands.UpdateScopeCommand
 import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractError
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetChildrenQuery
+import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetScopeQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListAliasesQuery
-import io.github.kamiazya.scopes.contracts.scopemanagement.queries.GetRootScopesQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.CreateScopeResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeResult

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/adapters/ScopeCommandAdapter.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/adapters/ScopeCommandAdapter.kt
@@ -14,6 +14,7 @@ import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListScopesWit
 import io.github.kamiazya.scopes.contracts.scopemanagement.queries.ListScopesWithQueryQuery
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.AliasListResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.CreateScopeResult
+import io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeListResult
 import io.github.kamiazya.scopes.contracts.scopemanagement.results.ScopeResult
 
 /**
@@ -112,7 +113,7 @@ class ScopeCommandAdapter(
     /**
      * Lists child scopes
      */
-    suspend fun listChildren(parentId: String, offset: Int, limit: Int): Either<ScopeContractError, List<ScopeResult>> {
+    suspend fun listChildren(parentId: String, offset: Int, limit: Int): Either<ScopeContractError, ScopeListResult> {
         val query = GetChildrenQuery(parentId = parentId, offset = offset, limit = limit)
         return scopeManagementPort.getChildren(query)
     }
@@ -120,7 +121,7 @@ class ScopeCommandAdapter(
     /**
      * Lists root scopes
      */
-    suspend fun listRootScopes(offset: Int, limit: Int): Either<ScopeContractError, List<ScopeResult>> =
+    suspend fun listRootScopes(offset: Int, limit: Int): Either<ScopeContractError, ScopeListResult> =
         scopeManagementPort.getRootScopes(GetRootScopesQuery(offset = offset, limit = limit))
 
     /**

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/CompletionCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/CompletionCommand.kt
@@ -40,12 +40,13 @@ class CompletionCommand :
             while (true) {
                 val page = scopeCommandAdapter
                     .listRootScopes(offset = offset, limit = pageLimit)
-                    .fold({ emptyList() }, { it })
+                    .fold({ null }, { it }) ?: break
 
-                if (page.isEmpty()) break
+                val items = page.scopes
+                if (items.isEmpty()) break
 
-                rootScopes.addAll(page)
-                if (page.size < pageLimit) break
+                rootScopes.addAll(items)
+                if (items.size < pageLimit) break
                 offset += pageLimit
             }
 
@@ -67,10 +68,10 @@ class CompletionCommand :
                             val localPairs = mutableSetOf<String>()
                             var childOffset = 0
                             while (true) {
-                                val children = scopeCommandAdapter
+                                val childPage = scopeCommandAdapter
                                     .listChildren(rootScope.id, offset = childOffset, limit = pageLimit)
-                                    .fold({ emptyList() }, { it })
-
+                                    .fold({ null }, { it }) ?: break
+                                val children = childPage.scopes
                                 if (children.isEmpty()) break
 
                                 children.forEach { child ->

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/CompletionCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/CompletionCommand.kt
@@ -28,7 +28,7 @@ class CompletionCommand :
     override fun run() {
         runBlocking {
             // Get all scopes to collect their aspects
-            scopeCommandAdapter.listRootScopes().fold(
+            scopeCommandAdapter.listRootScopes(offset = 0, limit = 1000).fold(
                 {
                     // On error, output nothing (silent failure for completion)
                 },
@@ -48,7 +48,7 @@ class CompletionCommand :
                     coroutineScope {
                         val jobs = scopes.map { rootScope ->
                             async {
-                                scopeCommandAdapter.listChildren(rootScope.id)
+                                scopeCommandAdapter.listChildren(rootScope.id, offset = 0, limit = 1000)
                             }
                         }
                         jobs.awaitAll().forEach { result ->

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
@@ -65,7 +65,7 @@ class ListCommand :
 
             when {
                 root -> {
-                    scopeCommandAdapter.listRootScopes().fold(
+                    scopeCommandAdapter.listRootScopes(offset, limit).fold(
                         { error ->
                             echo("Error: ${ContractErrorMessageMapper.getMessage(error)}", err = true)
                         },
@@ -86,7 +86,7 @@ class ListCommand :
                     )
                 }
                 parentId != null -> {
-                    scopeCommandAdapter.listChildren(parentId!!).fold(
+                    scopeCommandAdapter.listChildren(parentId!!, offset, limit).fold(
                         { error ->
                             echo("Error: ${ContractErrorMessageMapper.getMessage(error)}", err = true)
                         },
@@ -107,7 +107,7 @@ class ListCommand :
                 }
                 else -> {
                     // Default: list root scopes
-                    scopeCommandAdapter.listRootScopes().fold(
+                    scopeCommandAdapter.listRootScopes(offset, limit).fold(
                         { error ->
                             echo("Error: ${ContractErrorMessageMapper.getMessage(error)}", err = true)
                         },

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
@@ -100,7 +100,8 @@ class ListCommand :
                         { error ->
                             echo("Error: ${ContractErrorMessageMapper.getMessage(error)}", err = true)
                         },
-                        { scopes ->
+                        { page ->
+                            val scopes = page.scopes
                             val filteredScopes = if (aspectFilters.isNotEmpty()) {
                                 filterByAspects(scopes, aspectFilters)
                             } else {
@@ -124,7 +125,8 @@ class ListCommand :
                         { error ->
                             echo("Error: ${ContractErrorMessageMapper.getMessage(error)}", err = true)
                         },
-                        { scopes ->
+                        { page ->
+                            val scopes = page.scopes
                             val filteredScopes = if (aspectFilters.isNotEmpty()) {
                                 filterByAspects(scopes, aspectFilters)
                             } else {
@@ -148,7 +150,8 @@ class ListCommand :
                         { error ->
                             echo("Error: ${ContractErrorMessageMapper.getMessage(error)}", err = true)
                         },
-                        { scopes ->
+                        { page ->
+                            val scopes = page.scopes
                             val filteredScopes = if (aspectFilters.isNotEmpty()) {
                                 filterByAspects(scopes, aspectFilters)
                             } else {

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
@@ -45,6 +45,16 @@ class ListCommand :
 
     override fun run() {
         runBlocking {
+            // Validate pagination inputs
+            if (offset < 0) {
+                echo("Error: offset must be >= 0", err = true)
+                return@runBlocking
+            }
+            if (limit !in 1..1000) {
+                echo("Error: limit must be in 1..1000", err = true)
+                return@runBlocking
+            }
+
             // Parse aspect filters
             val aspectFilters = aspects.mapNotNull { aspectStr ->
                 val parts = aspectStr.split(":", limit = 2)
@@ -75,6 +85,9 @@ class ListCommand :
                             } else {
                                 scopes
                             }
+                            if (aspectFilters.isNotEmpty()) {
+                                echo("Note: aspect filtering is applied after pagination; adjust --offset/--limit to explore more matches.", err = true)
+                            }
 
                             if (verbose) {
                                 // Fetch aliases for each scope and display verbosely
@@ -96,6 +109,9 @@ class ListCommand :
                             } else {
                                 scopes
                             }
+                            if (aspectFilters.isNotEmpty()) {
+                                echo("Note: aspect filtering is applied after pagination; adjust --offset/--limit to explore more matches.", err = true)
+                            }
 
                             if (verbose) {
                                 echo(formatVerboseList(filteredScopes, debugContext))
@@ -116,6 +132,9 @@ class ListCommand :
                                 filterByAspects(scopes, aspectFilters)
                             } else {
                                 scopes
+                            }
+                            if (aspectFilters.isNotEmpty()) {
+                                echo("Note: aspect filtering is applied after pagination; adjust --offset/--limit to explore more matches.", err = true)
                             }
 
                             if (verbose) {

--- a/quality/konsist/src/test/kotlin/io/github/kamiazya/scopes/konsist/NullableAssertionRulesTest.kt
+++ b/quality/konsist/src/test/kotlin/io/github/kamiazya/scopes/konsist/NullableAssertionRulesTest.kt
@@ -21,20 +21,22 @@ class NullableAssertionRulesTest :
                     .filter { function ->
                         // Look for Either result patterns
                         function.text.contains("getOrNull()") &&
-                            (function.text.contains("shouldBe") || 
-                             function.text.contains("shouldHave") ||
-                             function.text.contains("shouldContain"))
+                            (
+                                function.text.contains("shouldBe") ||
+                                    function.text.contains("shouldHave") ||
+                                    function.text.contains("shouldContain")
+                                )
                     }
                     .assertTrue { function ->
                         // Should check isRight() before getOrNull()
                         val hasRightCheck = function.text.contains("isRight() shouldBe true") ||
                             function.text.contains("isRight()).isTrue()") ||
                             function.text.contains("shouldBeRight()")
-                        
+
                         // Allow direct comparison to null or empty
                         val isNullOrEmptyCheck = function.text.contains("getOrNull() shouldBe null") ||
                             function.text.contains("getOrNull() shouldBe emptyList")
-                        
+
                         hasRightCheck || isNullOrEmptyCheck
                     }
             }
@@ -56,7 +58,7 @@ class NullableAssertionRulesTest :
                         val hasExplanatoryComment = function.text.contains("nullable") ||
                             function.text.contains("optional") ||
                             function.text.contains("may be null")
-                        
+
                         hasNonNullAssertion || hasExplanatoryComment
                     }
             }
@@ -77,7 +79,7 @@ class NullableAssertionRulesTest :
                         val hasProperAssertion = function.text.contains("shouldNotBe null") ||
                             function.text.contains("getOrNull()!!") ||
                             function.text.contains("isRight() shouldBe true")
-                        
+
                         !hasNullableChaining || hasProperAssertion
                     }
             }
@@ -99,7 +101,7 @@ class NullableAssertionRulesTest :
                             function.text.contains("leftOrNull()") ||
                             function.text.contains("shouldBeLeft()")
                         val hasErrorAssertion = function.text.contains("shouldBeInstanceOf")
-                        
+
                         hasRightCheck || hasLeftHandling || hasErrorAssertion
                     }
             }
@@ -120,7 +122,7 @@ class NullableAssertionRulesTest :
                             function.text.contains("as? ")
                         val hasGenericErrorCheck = function.text.contains("shouldNotBe null") ||
                             function.text.contains("shouldBe true")
-                        
+
                         hasTypeAssertion || hasGenericErrorCheck
                     }
             }

--- a/quality/konsist/src/test/kotlin/io/github/kamiazya/scopes/konsist/TimestampTestingRulesTest.kt
+++ b/quality/konsist/src/test/kotlin/io/github/kamiazya/scopes/konsist/TimestampTestingRulesTest.kt
@@ -29,7 +29,7 @@ class TimestampTestingRulesTest :
                             function.text.contains("Clock.System.now()")
                         val hasExplanation = function.text.contains("deterministic") ||
                             function.text.contains("clock advancement")
-                        
+
                         hasClockWait && hasExplanation
                     }
             }
@@ -49,7 +49,7 @@ class TimestampTestingRulesTest :
                         val hasDoWhile = function.text.contains("do {") &&
                             function.text.contains("} while")
                         val hasSimpleWhile = function.text.contains("while (Clock.System.now()")
-                        
+
                         // Allow either pattern but prefer do-while
                         hasDoWhile || hasSimpleWhile
                     }
@@ -72,7 +72,7 @@ class TimestampTestingRulesTest :
                             function.text.contains("= Clock.System.now()")
                         val hasDoWhileCapture = function.text.contains("do {") &&
                             function.text.contains("Clock.System.now()")
-                        
+
                         hasTimestampVar || hasDoWhileCapture
                     }
             }
@@ -89,16 +89,16 @@ class TimestampTestingRulesTest :
                     .assertTrue { function ->
                         // Should use captured timestamp variables for occurredAt
                         val hasCapturedTime = function.text.matches(
-                            Regex(".*val\\s+\\w+Time\\s*=\\s*Clock\\.System\\.now\\(\\).*", RegexOption.DOT_MATCHES_ALL)
+                            Regex(".*val\\s+\\w+Time\\s*=\\s*Clock\\.System\\.now\\(\\).*", RegexOption.DOT_MATCHES_ALL),
                         )
                         val usesVariableForOccurredAt = function.text.matches(
-                            Regex(".*occurredAt\\s*=\\s*\\w+Time.*", RegexOption.DOT_MATCHES_ALL)
+                            Regex(".*occurredAt\\s*=\\s*\\w+Time.*", RegexOption.DOT_MATCHES_ALL),
                         )
-                        
+
                         // Allow direct Clock.System.now() if not doing boundary testing
                         val isSimpleTest = !function.text.contains("timestampBetween") &&
                             !function.text.contains("since")
-                        
+
                         isSimpleTest || (hasCapturedTime && usesVariableForOccurredAt)
                     }
             }
@@ -116,11 +116,11 @@ class TimestampTestingRulesTest :
                         val hasExplanation = file.text.contains("ensure") ||
                             file.text.contains("guarantee") ||
                             file.text.contains("deterministic")
-                        
+
                         // Better to use clock advancement
                         val hasClockAdvancement = file.text.contains("while") &&
                             file.text.contains("Clock.System.now()")
-                        
+
                         hasExplanation || hasClockAdvancement
                     }
             }


### PR DESCRIPTION
## Summary
Implement efficient database-side pagination for scopes and wire CLI `--offset/--limit` end-to-end.

Closes #116

## Changes
- SQLDelight: add paginated queries `findRootScopesPaged` and `findScopesByParentIdPaged` (ORDER BY created_at ASC, LIMIT/OFFSET)
- Repository: extend `ScopeRepository` with `findByParentId(parentId, offset, limit)` and implement in `SqlDelightScopeRepository`
- Application: update `GetRootScopesHandler` and `GetChildrenHandler` to call repository with pagination (removed in-memory `drop/take`)
- Contracts: add `GetRootScopesQuery`, extend `GetChildrenQuery` to carry `offset` and `limit`
- Port/Adapter: change `ScopeManagementPort.getRootScopes(query)` and map both queries to application handlers with pagination
- CLI: plumb `--offset/--limit` through `ScopeCommandAdapter`, `list` command, and completion command

## Rationale
Previously, pagination was done in-memory after loading all scopes, which does not scale. Delegating pagination to the DB dramatically reduces memory usage and improves performance.

## Ordering
Pagination uses `created_at ASC` to provide a stable order, matching the previous handler-side sort direction while enabling deterministic paging.

## Backward Compatibility
- Contract change: `getRootScopes()` replaced by `getRootScopes(query: GetRootScopesQuery)`; `GetChildrenQuery` gains `offset/limit` with defaults. Implementations updated accordingly in this repo.
- CLI behavior remains compatible; new flags `--offset/--limit` now take effect through to the repository.

## Testing
- Updated modules compile successfully
- All unit tests in affected modules pass locally:
  - `:scope-management-domain`
  - `:scope-management-application`
  - `:scope-management-infrastructure`
  - `:contracts-scope-management`
- Manual verification via CLI assembly

## Notes
- If needed, we can further extend pagination to additional list endpoints (e.g., alias listings) following the same pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination for listing root and child scopes (offset, limit) with deterministic ordering.
  - CLI: list and completion commands accept --offset and --limit (defaults: offset=0, limit=100; completion pages with larger page size).
- **Performance**
  - Database-side paging and indexing reduce memory use and improve listing performance for large scope sets.
- **Behavior**
  - Aspect filtering is applied after pagination; note shown when filters are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->