### PR TITLE
chore: remove unused Exposed dependency declarations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,6 @@ konsist = "0.17.3"
 
 # Database and persistence
 sqlite = "3.50.3.0"
-exposed = "0.57.0"
 sqldelight = "2.1.0"
 
 # Logging
@@ -50,10 +49,6 @@ konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 
 # Database and persistence
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
-exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
-exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
 sqldelight-driver-sqlite = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }


### PR DESCRIPTION
## Summary
- Remove unused Exposed ORM library declarations from the project
- The codebase exclusively uses SqlDelight for database access
- No actual code changes required, only dependency cleanup

## Changes
- Removed `exposed` version definition (0.57.0) from libs.versions.toml
- Removed 4 Exposed library declarations:
  - exposed-core
  - exposed-jdbc
  - exposed-dao
  - exposed-kotlin-datetime

## Test plan
- [x] Ran `./gradlew test` - all tests pass
- [x] Ran `./gradlew konsistTest` - architecture validation passes
- [x] Verified no Exposed imports or usage in the codebase with grep search
- [x] Confirmed SqlDelight continues to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Removed backend ORM dependencies from the project's dependency catalog.
  * Impact: slightly smaller application footprint, fewer transitive dependencies, and faster build/download times.
  * No changes to user-facing features, UI, or platform behavior; existing functionality and data are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->