### PR TITLE
feat(cli): support '=' delimiter for --aspect (list)

### DIFF
--- a/docs/guides/shell-completion.md
+++ b/docs/guides/shell-completion.md
@@ -50,8 +50,11 @@ The `list` command supports filtering by aspects (tags) with shell completion:
 
 ```bash
 # List scopes with specific aspects
+# Both key:value and key=value are supported
 scopes list --aspect priority:high
+scopes list --aspect priority=high
 scopes list -a status:active -a priority:high
+scopes list -a status=active -a priority=high
 
 # Tab completion will suggest available aspect:value pairs
 scopes list --aspect <TAB>
@@ -60,16 +63,18 @@ scopes list --aspect <TAB>
 ### How It Works
 
 1. When you type `scopes list --aspect <TAB>`, the shell completion script calls `scopes _complete-aspects`
-2. This hidden command queries root scopes and their children for available aspect key:value pairs
+2. This hidden command queries root scopes and their children for available aspect key:value pairs (also valid with key=value)
 3. The results are presented as completion candidates
 
 ### Multiple Aspect Filters
 
-You can specify multiple aspect filters. A scope matches if it has ALL the specified aspects:
+You can specify multiple aspect filters (either key:value or key=value). A scope matches if it has ALL the specified aspects:
 
 ```bash
 # Find scopes that have both "priority:high" AND "status:active"
 scopes list --aspect priority:high --aspect status:active
+# Or using '='
+scopes list --aspect priority=high --aspect status=active
 
 # Short form
 scopes list -a priority:high -a status:active

--- a/docs/guides/shell-completion.md
+++ b/docs/guides/shell-completion.md
@@ -118,3 +118,9 @@ The aspect completion feature consists of:
 3. **Shell completion script**: Calls the hidden command to get suggestions.
 
 This design allows dynamic completion based on actual database content rather than static lists.
+
+## Notes on Delimiters and Quoting
+
+- The parser splits on the first `:` or `=` only; additional `:`/`=` remain in the value. Example: `version=v:1` parses as key `version`, value `v:1`.
+- Escaping of delimiters (like `\:` or `\=`) is not supported. If values contain spaces, quote them using your shell: `--aspect "status=in progress"`.
+- Completion suggestions are shown in `key:value` form, but input accepts both `key:value` and `key=value`.

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/AspectParsing.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/AspectParsing.kt
@@ -1,0 +1,35 @@
+package io.github.kamiazya.scopes.interfaces.cli.commands
+
+/**
+ * Parse a single aspect entry string into key/value pair.
+ * Supports both `key:value` and `key=value` formats.
+ */
+fun parseAspectEntry(entry: String): Pair<String, String>? {
+    if (entry.isBlank()) return null
+
+    val idxColon = entry.indexOf(':')
+    val idxEq = entry.indexOf('=')
+
+    val idx = when {
+        idxColon >= 0 && idxEq >= 0 -> minOf(idxColon, idxEq)
+        idxColon >= 0 -> idxColon
+        idxEq >= 0 -> idxEq
+        else -> -1
+    }
+    if (idx < 0) return null
+
+    val key = entry.substring(0, idx).trim()
+    val value = entry.substring(idx + 1).trim()
+    if (key.isEmpty() || value.isEmpty()) return null
+    return key to value
+}
+
+/**
+ * Parse multiple aspect filter strings into a grouped map keyed by aspect key.
+ * Each input can be formatted as `key:value` or `key=value`.
+ * Invalid entries are ignored.
+ */
+fun parseAspectFilters(entries: List<String>): Map<String, List<String>> =
+    entries.mapNotNull { parseAspectEntry(it) }
+        .groupBy({ it.first }, { it.second })
+

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
@@ -40,7 +40,7 @@ class ListCommand :
     private val aspects by option(
         "-a",
         "--aspect",
-        help = "Filter by aspect (format: key:value or key=value). Can be specified multiple times.",
+        help = "Filter by aspect (format: key:value or key=value). Splits on the first delimiter; subsequent ':' or '=' are part of the value. Use shell quotes if values contain spaces. Can be specified multiple times.",
         completionCandidates = CompletionCandidates.Custom.fromStdout("scopes _complete-aspects"),
     ).multiple()
 

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
@@ -40,7 +40,7 @@ class ListCommand :
     private val aspects by option(
         "-a",
         "--aspect",
-        help = "Filter by aspect (format: key:value). Can be specified multiple times.",
+        help = "Filter by aspect (format: key:value or key=value). Can be specified multiple times.",
         completionCandidates = CompletionCandidates.Custom.fromStdout("scopes _complete-aspects"),
     ).multiple()
 
@@ -56,23 +56,15 @@ class ListCommand :
                 return@runBlocking
             }
 
-            // Parse aspect filters
-            val aspectFilters = aspects.mapNotNull { aspectStr ->
-                val parts = aspectStr.split(":", limit = 2)
-                if (parts.size == 2) {
-                    val key = parts[0].trim()
-                    val value = parts[1].trim()
-                    if (key.isEmpty() || value.isEmpty()) {
-                        echo("Warning: Invalid aspect format: $aspectStr (expected non-empty key:value)", err = true)
-                        null
-                    } else {
-                        key to value
-                    }
-                } else {
-                    echo("Warning: Invalid aspect format: $aspectStr (expected key:value)", err = true)
-                    null
-                }
-            }.groupBy({ it.first }, { it.second })
+            // Parse aspect filters (supports key:value and key=value)
+            val aspectFilters = parseAspectFilters(aspects)
+            val invalidAspects = aspects.filter { parseAspectEntry(it) == null }
+            invalidAspects.forEach { invalid ->
+                echo(
+                    "Warning: Invalid aspect format: $invalid (expected key:value or key=value)",
+                    err = true,
+                )
+            }
 
             when {
                 query != null -> {

--- a/interfaces/cli/src/test/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommandAspectParsingTest.kt
+++ b/interfaces/cli/src/test/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommandAspectParsingTest.kt
@@ -36,6 +36,13 @@ class ListCommandAspectParsingTest : DescribeSpec({
             result["status"]!!.shouldContainExactlyInAnyOrder("ready")
         }
 
+        it("preserves additional delimiters in values") {
+            val result = parseAspectFilters(listOf("version:v:1", "build=a=b"))
+
+            result["version"]!!.shouldContainExactlyInAnyOrder("v:1")
+            result["build"]!!.shouldContainExactlyInAnyOrder("a=b")
+        }
+
         it("ignores invalid entries without key or value") {
             val result = parseAspectFilters(listOf(":nope", "=nope", "keyonly:", "valu e", ""))
 
@@ -43,4 +50,3 @@ class ListCommandAspectParsingTest : DescribeSpec({
         }
     }
 })
-

--- a/interfaces/cli/src/test/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommandAspectParsingTest.kt
+++ b/interfaces/cli/src/test/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommandAspectParsingTest.kt
@@ -1,0 +1,46 @@
+package io.github.kamiazya.scopes.interfaces.cli.commands
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.shouldContainExactly
+
+class ListCommandAspectParsingTest : DescribeSpec({
+    describe("parseAspectFilters") {
+        it("parses key:value and key=value formats") {
+            val result = parseAspectFilters(listOf("priority:high", "status=active"))
+
+            result.shouldContainExactly(
+                mapOf(
+                    "priority" to listOf("high"),
+                    "status" to listOf("active"),
+                ),
+            )
+        }
+
+        it("trims whitespace around keys and values") {
+            val result = parseAspectFilters(listOf("  priority  :  high  ", " status = active "))
+
+            result.shouldContainExactly(
+                mapOf(
+                    "priority" to listOf("high"),
+                    "status" to listOf("active"),
+                ),
+            )
+        }
+
+        it("groups multiple values for the same key") {
+            val result = parseAspectFilters(listOf("priority:high", "priority=critical", "status:ready"))
+
+            // Order of values is not important
+            result["priority"]!!.shouldContainExactlyInAnyOrder("high", "critical")
+            result["status"]!!.shouldContainExactlyInAnyOrder("ready")
+        }
+
+        it("ignores invalid entries without key or value") {
+            val result = parseAspectFilters(listOf(":nope", "=nope", "keyonly:", "valu e", ""))
+
+            result.shouldContainExactly(emptyMap())
+        }
+    }
+})
+


### PR DESCRIPTION
This PR addresses #111 by adding support for alternative key-value delimiters in the CLI list command.

Changes:
- Accept both `key:value` and `key=value` formats for `--aspect` / `-a`
- Update help text in `ListCommand`
- Add `parseAspectEntry` / `parseAspectFilters` helpers
- Add unit tests covering both delimiter types
- Update docs (shell-completion guide) to mention and demonstrate both forms

Validation:
- Ran `:interfaces-cli:test` (green)
- `assemble` succeeds for the repo
- `:interfaces-cli:detekt` and `:quality-konsist:test` pass

Notes:
- Completion suggestions continue to output `key:value`, but input accepts both `:` and `=` as requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI aspect filters now support both key:value and key=value formats, including mixed usage.
  * Whitespace is trimmed; multiple values per key are aggregated.
  * Invalid entries are ignored with clearer warnings about expected formats.

* **Documentation**
  * Updated shell-completion guide to reflect dual-syntax support with new examples and clarified multi-filter guidance.

* **Tests**
  * Added tests covering colon/equal separators, whitespace trimming, value aggregation, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->