### PR TITLE
style(cli): apply Spotless formatting after #151

### DIFF
--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/AspectParsing.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/AspectParsing.kt
@@ -29,7 +29,5 @@ fun parseAspectEntry(entry: String): Pair<String, String>? {
  * Each input can be formatted as `key:value` or `key=value`.
  * Invalid entries are ignored.
  */
-fun parseAspectFilters(entries: List<String>): Map<String, List<String>> =
-    entries.mapNotNull { parseAspectEntry(it) }
-        .groupBy({ it.first }, { it.second })
-
+fun parseAspectFilters(entries: List<String>): Map<String, List<String>> = entries.mapNotNull { parseAspectEntry(it) }
+    .groupBy({ it.first }, { it.second })

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommand.kt
@@ -40,7 +40,7 @@ class ListCommand :
     private val aspects by option(
         "-a",
         "--aspect",
-        help = "Filter by aspect (format: key:value or key=value). Splits on the first delimiter; subsequent ':' or '=' are part of the value. Use shell quotes if values contain spaces. Can be specified multiple times.",
+        help = "Filter by aspect: key:value or key=value. First delimiter splits; later ':'/'=' stay in value. Quote values with spaces. Repeatable.",
         completionCandidates = CompletionCandidates.Custom.fromStdout("scopes _complete-aspects"),
     ).multiple()
 

--- a/interfaces/cli/src/test/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommandAspectParsingTest.kt
+++ b/interfaces/cli/src/test/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/ListCommandAspectParsingTest.kt
@@ -4,49 +4,50 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.maps.shouldContainExactly
 
-class ListCommandAspectParsingTest : DescribeSpec({
-    describe("parseAspectFilters") {
-        it("parses key:value and key=value formats") {
-            val result = parseAspectFilters(listOf("priority:high", "status=active"))
+class ListCommandAspectParsingTest :
+    DescribeSpec({
+        describe("parseAspectFilters") {
+            it("parses key:value and key=value formats") {
+                val result = parseAspectFilters(listOf("priority:high", "status=active"))
 
-            result.shouldContainExactly(
-                mapOf(
-                    "priority" to listOf("high"),
-                    "status" to listOf("active"),
-                ),
-            )
+                result.shouldContainExactly(
+                    mapOf(
+                        "priority" to listOf("high"),
+                        "status" to listOf("active"),
+                    ),
+                )
+            }
+
+            it("trims whitespace around keys and values") {
+                val result = parseAspectFilters(listOf("  priority  :  high  ", " status = active "))
+
+                result.shouldContainExactly(
+                    mapOf(
+                        "priority" to listOf("high"),
+                        "status" to listOf("active"),
+                    ),
+                )
+            }
+
+            it("groups multiple values for the same key") {
+                val result = parseAspectFilters(listOf("priority:high", "priority=critical", "status:ready"))
+
+                // Order of values is not important
+                result["priority"]!!.shouldContainExactlyInAnyOrder("high", "critical")
+                result["status"]!!.shouldContainExactlyInAnyOrder("ready")
+            }
+
+            it("preserves additional delimiters in values") {
+                val result = parseAspectFilters(listOf("version:v:1", "build=a=b"))
+
+                result["version"]!!.shouldContainExactlyInAnyOrder("v:1")
+                result["build"]!!.shouldContainExactlyInAnyOrder("a=b")
+            }
+
+            it("ignores invalid entries without key or value") {
+                val result = parseAspectFilters(listOf(":nope", "=nope", "keyonly:", "valu e", ""))
+
+                result.shouldContainExactly(emptyMap())
+            }
         }
-
-        it("trims whitespace around keys and values") {
-            val result = parseAspectFilters(listOf("  priority  :  high  ", " status = active "))
-
-            result.shouldContainExactly(
-                mapOf(
-                    "priority" to listOf("high"),
-                    "status" to listOf("active"),
-                ),
-            )
-        }
-
-        it("groups multiple values for the same key") {
-            val result = parseAspectFilters(listOf("priority:high", "priority=critical", "status:ready"))
-
-            // Order of values is not important
-            result["priority"]!!.shouldContainExactlyInAnyOrder("high", "critical")
-            result["status"]!!.shouldContainExactlyInAnyOrder("ready")
-        }
-
-        it("preserves additional delimiters in values") {
-            val result = parseAspectFilters(listOf("version:v:1", "build=a=b"))
-
-            result["version"]!!.shouldContainExactlyInAnyOrder("v:1")
-            result["build"]!!.shouldContainExactlyInAnyOrder("a=b")
-        }
-
-        it("ignores invalid entries without key or value") {
-            val result = parseAspectFilters(listOf(":nope", "=nope", "keyonly:", "valu e", ""))
-
-            result.shouldContainExactly(emptyMap())
-        }
-    }
-})
+    })


### PR DESCRIPTION
Spotless/ktlint flagged formatting issues post-merge of #151 on main.\n\nChanges:\n- Shorten --aspect help text line to satisfy max-line-length\n- Apply Spotless formatting to the new CLI test and parsing files\n\nBuild & Tests:\n- Ran `clean build` locally (all modules green)