### PR TITLE
Improve test ordering consistency in repository tests (#120)

### DIFF
--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeAliasRepository.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeAliasRepository.kt
@@ -69,6 +69,8 @@ interface ScopeAliasRepository {
      * Finds aliases whose names start with the given prefix.
      * Used for tab completion and partial matching.
      *
+     * Ordering: deterministic, by alias name ascending (ties broken by `id DESC`).
+     *
      * @param prefix The prefix to match
      * @param limit Maximum number of results to return
      * @return Either a persistence error or the list of matching aliases
@@ -125,6 +127,8 @@ interface ScopeAliasRepository {
 
     /**
      * Lists all aliases with pagination support.
+     *
+     * Ordering: deterministic, newest first (ordered by `created_at DESC, id DESC`).
      *
      * @param offset The number of aliases to skip
      * @param limit The maximum number of aliases to return

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/repository/ScopeRepository.kt
@@ -25,11 +25,16 @@ interface ScopeRepository {
 
     /**
      * Find all scopes.
+     *
+     * Ordering: deterministic, newest first (ordered by `created_at DESC, id DESC`).
+     * Use the paginated overload for large datasets.
      */
     suspend fun findAll(): Either<PersistenceError, List<Scope>>
 
     /**
      * Find all scopes with pagination.
+     *
+     * Ordering: deterministic, newest first (ordered by `created_at DESC, id DESC`).
      */
     suspend fun findAll(offset: Int, limit: Int): Either<PersistenceError, List<Scope>>
 
@@ -41,8 +46,9 @@ interface ScopeRepository {
 
     /**
      * Find scopes by parent ID with pagination.
-     * Results are ordered by creation time ascending to provide stable paging.
-     * When parentId is null, returns root scopes.
+     * Results are ordered by creation time ascending to provide stable paging
+     * within a parent group (ties broken by `id ASC`). When parentId is null,
+     * returns root scopes.
      */
     suspend fun findByParentId(parentId: ScopeId?, offset: Int, limit: Int): Either<PersistenceError, List<Scope>>
 

--- a/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/ScopeAlias.sq
+++ b/contexts/scope-management/infrastructure/src/main/sqldelight/io/github/kamiazya/scopes/scopemanagement/db/ScopeAlias.sq
@@ -42,7 +42,7 @@ findByScopeId:
 SELECT *
 FROM scope_aliases
 WHERE scope_id = ?
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC;
 
 -- Find canonical alias for scope
 findCanonicalAlias:
@@ -56,14 +56,14 @@ findByTypeForScope:
 SELECT *
 FROM scope_aliases
 WHERE scope_id = ? AND alias_type = ?
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC;
 
 -- Find aliases by prefix
 findByPrefix:
 SELECT *
 FROM scope_aliases
 WHERE alias_name LIKE ?
-ORDER BY alias_name;
+ORDER BY alias_name ASC, id DESC;
 
 -- Check if alias exists
 existsByAliasName:
@@ -95,4 +95,4 @@ FROM scope_aliases;
 getAllAliases:
 SELECT *
 FROM scope_aliases
-ORDER BY created_at DESC;
+ORDER BY created_at DESC, id DESC;

--- a/quality/konsist/src/test/kotlin/io/github/kamiazya/scopes/konsist/RepositoryOrderingConsistencyTest.kt
+++ b/quality/konsist/src/test/kotlin/io/github/kamiazya/scopes/konsist/RepositoryOrderingConsistencyTest.kt
@@ -1,0 +1,45 @@
+package io.github.kamiazya.scopes.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.verify.assertTrue
+import io.kotest.core.spec.style.DescribeSpec
+
+/**
+ * Konsist rules to prevent order-sensitive assertions in repository tests
+ * unless ordering is explicitly guaranteed by the repository contract.
+ */
+class RepositoryOrderingConsistencyTest : DescribeSpec({
+    describe("Repository ordering consistency") {
+
+        it("repository tests should avoid order-sensitive list equality for general queries") {
+            val orderSensitiveMatchers = listOf(
+                "shouldBe listOf(",
+                "shouldContainExactly",
+                "shouldBeExactly",
+            )
+
+            val repoCallsWithoutExplicitOrder = listOf(
+                // General fetches where ordering should not be asserted strictly in tests
+                ".findAll()",
+                ".findAll(", // paginated overload
+                ".listAll(",
+                ".findByAliasNamePrefix(",
+            )
+
+            Konsist.scopeFromTest()
+                .files
+                .withNameEndingWith("RepositoryTest.kt")
+                .flatMap { it.functions() }
+                .assertTrue { function ->
+                    val text = function.text
+                    val usesOrderSensitiveMatcher = orderSensitiveMatchers.any { text.contains(it) }
+                    val callsNonOrderedRepoMethod = repoCallsWithoutExplicitOrder.any { text.contains(it) }
+
+                    // If a test calls a non-ordered repository method, it should not assert exact order
+                    !(usesOrderSensitiveMatcher && callsNonOrderedRepoMethod)
+                }
+        }
+    }
+})
+


### PR DESCRIPTION
This PR addresses #120 by making repository tests robust to ordering differences and ensuring deterministic ordering where guaranteed.\n\nChanges:\n- SQL: Add secondary ORDER BY id for alias queries that were previously only ordered by created_at (deterministic ordering across engines).\n- Docs: Clarify ordering guarantees in ScopeRepository and ScopeAliasRepository KDoc (findAll/newest-first; parent paging ascending; alias prefix by name asc).\n- Konsist: Add architecture test to guard against order-sensitive assertions in repository tests for non-ordered methods.\n- Build: All tests and konsist checks pass locally.\n\nNotes:\n- No public API changes to repository interfaces beyond documentation.\n- Behavior is unchanged except for deterministic tie-breakers in alias queries.\n\nValidation:\n- Ran `./gradlew test konsistTest` successfully.\n\nIf you'd like me to extend paging at prefix search (offset param), I can follow-up in a separate issue/PR.