### PR TITLE
fix: Move AspectQueryParser to domain layer (Clean Architecture)

### DIFF
--- a/apps/scopes/src/test/kotlin/io/github/kamiazya/scopes/apps/cli/integration/AspectQueryIntegrationTest.kt
+++ b/apps/scopes/src/test/kotlin/io/github/kamiazya/scopes/apps/cli/integration/AspectQueryIntegrationTest.kt
@@ -1,12 +1,12 @@
 package io.github.kamiazya.scopes.apps.cli.integration
 
 import arrow.core.toNonEmptyListOrNull
-import io.github.kamiazya.scopes.scopemanagement.application.query.AspectQueryParser
 import io.github.kamiazya.scopes.scopemanagement.application.query.FilterScopesWithQueryUseCase
 import io.github.kamiazya.scopes.scopemanagement.domain.entity.AspectDefinition
 import io.github.kamiazya.scopes.scopemanagement.domain.entity.Scope
 import io.github.kamiazya.scopes.scopemanagement.domain.repository.AspectDefinitionRepository
 import io.github.kamiazya.scopes.scopemanagement.domain.repository.ScopeRepository
+import io.github.kamiazya.scopes.scopemanagement.domain.service.query.AspectQueryParser
 import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.*
 import io.github.kamiazya.scopes.scopemanagement.infrastructure.repository.InMemoryAspectDefinitionRepository
 import io.github.kamiazya.scopes.scopemanagement.infrastructure.repository.InMemoryScopeRepository

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/AspectQueryEvaluator.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/AspectQueryEvaluator.kt
@@ -1,6 +1,8 @@
 package io.github.kamiazya.scopes.scopemanagement.application.query
 
 import io.github.kamiazya.scopes.scopemanagement.domain.entity.AspectDefinition
+import io.github.kamiazya.scopes.scopemanagement.domain.service.query.AspectQueryAST
+import io.github.kamiazya.scopes.scopemanagement.domain.service.query.ComparisonOperator
 import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.AspectType
 import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.AspectValue
 import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.Aspects

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/FilterScopesWithQueryUseCase.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/FilterScopesWithQueryUseCase.kt
@@ -4,12 +4,13 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import io.github.kamiazya.scopes.scopemanagement.application.query.AspectQueryEvaluator
-import io.github.kamiazya.scopes.scopemanagement.application.query.AspectQueryParser
 import io.github.kamiazya.scopes.scopemanagement.application.usecase.UseCase
 import io.github.kamiazya.scopes.scopemanagement.domain.entity.Scope
 import io.github.kamiazya.scopes.scopemanagement.domain.error.ScopesError
 import io.github.kamiazya.scopes.scopemanagement.domain.repository.AspectDefinitionRepository
 import io.github.kamiazya.scopes.scopemanagement.domain.repository.ScopeRepository
+import io.github.kamiazya.scopes.scopemanagement.domain.service.query.AspectQueryParser
+import io.github.kamiazya.scopes.scopemanagement.domain.service.query.QueryParseError
 import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.ScopeId
 
 /**
@@ -123,24 +124,24 @@ class FilterScopesWithQueryUseCase(
         return filteredScopes.right()
     }
 
-    private fun formatParseError(error: io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError): String = when (error) {
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.EmptyQuery ->
+    private fun formatParseError(error: QueryParseError): String = when (error) {
+        is QueryParseError.EmptyQuery ->
             "Query cannot be empty"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.UnexpectedCharacter ->
+        is QueryParseError.UnexpectedCharacter ->
             "Unexpected character '${error.char}' at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.UnterminatedString ->
+        is QueryParseError.UnterminatedString ->
             "Unterminated string at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.UnexpectedToken ->
+        is QueryParseError.UnexpectedToken ->
             "Unexpected token at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.MissingClosingParen ->
+        is QueryParseError.MissingClosingParen ->
             "Missing closing parenthesis at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.ExpectedExpression ->
+        is QueryParseError.ExpectedExpression ->
             "Expected expression at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.ExpectedIdentifier ->
+        is QueryParseError.ExpectedIdentifier ->
             "Expected identifier at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.ExpectedOperator ->
+        is QueryParseError.ExpectedOperator ->
             "Expected operator at position ${error.position}"
-        is io.github.kamiazya.scopes.scopemanagement.application.query.QueryParseError.ExpectedValue ->
+        is QueryParseError.ExpectedValue ->
             "Expected value at position ${error.position}"
     }
 }

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/service/query/AspectQueryAST.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/service/query/AspectQueryAST.kt
@@ -1,4 +1,4 @@
-package io.github.kamiazya.scopes.scopemanagement.application.query
+package io.github.kamiazya.scopes.scopemanagement.domain.service.query
 
 /**
  * Abstract Syntax Tree for aspect queries.

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/service/query/AspectQueryParser.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/service/query/AspectQueryParser.kt
@@ -1,4 +1,4 @@
-package io.github.kamiazya.scopes.scopemanagement.application.query
+package io.github.kamiazya.scopes.scopemanagement.domain.service.query
 
 import arrow.core.Either
 import arrow.core.left


### PR DESCRIPTION
## Summary
- Fixes layering violation by moving query parsing logic from application layer to domain service layer
- Moves AspectQueryParser, AspectQueryAST, ComparisonOperator, and QueryParseError to domain layer
- Updates all import statements in dependent files

## Architecture Impact
This change resolves a Clean Architecture violation where business logic (query parsing) was incorrectly placed in the application layer. Query parsing is domain logic and belongs in the domain service layer.

## Files Changed
- **Moved**: AspectQueryParser from application/query to domain/service/query
- **Moved**: AspectQueryAST and related types to domain/service/query
- **Updated**: Import statements in FilterScopesWithQueryUseCase and AspectQueryIntegrationTest
- **Updated**: AspectQueryEvaluator imports

## Test plan
- [x] All modules compile successfully
- [x] Pre-commit hooks (linting, formatting) pass
- [ ] Run full test suite to ensure no regressions
- [ ] Run Konsist architecture tests to verify compliance

Closes #177

🤖 Generated with [Claude Code](https://claude.ai/code)