### PR TITLE
Remove Oracle GraalVM dependency and use Syft for binary SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,19 @@ jobs:
         with:
           validate-wrappers: true
 
+      - name: Install Syft (SBOM generation tool)
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Installing Syft for binary SBOM generation..."
+          
+          # Install Syft using the official installer
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          
+          # Verify installation
+          syft version
+          echo "Syft installed successfully"
+
       - name: Extract version from tag
         id: version
         shell: bash
@@ -142,6 +155,25 @@ jobs:
           echo "binary_name=$BINARY_NAME" >> $GITHUB_OUTPUT
         id: binary
 
+      - name: Generate binary SBOM using Syft
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Generating binary SBOM for: ${{ steps.binary.outputs.binary_name }}"
+          
+          # Generate SBOM using Syft in CycloneDX format
+          syft "${{ steps.binary.outputs.binary_name }}" -o cyclonedx-json > "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json"
+          
+          echo "Successfully generated binary SBOM using Syft"
+          echo "Generated files:"
+          ls -la sbom-image-*
+          
+          # Verify the SBOM is valid JSON
+          if command -v jq &> /dev/null; then
+            echo "Validating SBOM JSON structure..."
+            jq empty "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json" && echo "SBOM JSON is valid" || echo "Warning: SBOM JSON may be invalid"
+          fi
+
       - name: Generate SBOM (CycloneDX) (Windows)
         if: matrix.platform == 'win32'
         run: |
@@ -191,7 +223,7 @@ jobs:
           echo "Generated hash file content:"
           cat binary-hash-${{ matrix.platform }}-${{ matrix.arch }}.txt
 
-          # Generate hashes for SBOM files with fallback detection
+          # Generate hashes for build-time SBOM files with fallback detection
           if [ "${{ matrix.platform }}" = "win32" ]; then
             # Check for SBOM files in the default location first
             if [ -f "/c/build-workspace/scopes/apps/scopes/build/reports/bom.json" ]; then
@@ -202,7 +234,7 @@ jobs:
               SBOM_JSON_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/cyclonedx/bom.json"
               SBOM_XML_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/cyclonedx/bom.xml"
             else
-              echo "Warning: SBOM files not found in expected locations"
+              echo "Warning: Build-time SBOM files not found in expected locations"
               SBOM_JSON_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/bom.json"
               SBOM_XML_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/bom.xml"
             fi
@@ -216,7 +248,7 @@ jobs:
               SBOM_JSON_PATH="apps/scopes/build/reports/cyclonedx/bom.json"
               SBOM_XML_PATH="apps/scopes/build/reports/cyclonedx/bom.xml"
             else
-              echo "Warning: SBOM files not found in expected locations"
+              echo "Warning: Build-time SBOM files not found in expected locations"
               SBOM_JSON_PATH="apps/scopes/build/reports/bom.json"
               SBOM_XML_PATH="apps/scopes/build/reports/bom.xml"
             fi
@@ -231,7 +263,7 @@ jobs:
             else
               SBOM_JSON_HASH=$(sha256sum "$SBOM_JSON_PATH" | awk '{print $1}')
             fi
-            echo "sbom-${{ matrix.platform }}-${{ matrix.arch }}.json:$SBOM_JSON_HASH" >> hashes.txt
+            echo "sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.json:$SBOM_JSON_HASH" >> hashes.txt
           fi
 
           if [ -f "$SBOM_XML_PATH" ]; then
@@ -243,7 +275,20 @@ jobs:
             else
               SBOM_XML_HASH=$(sha256sum "$SBOM_XML_PATH" | awk '{print $1}')
             fi
-            echo "sbom-${{ matrix.platform }}-${{ matrix.arch }}.xml:$SBOM_XML_HASH" >> hashes.txt
+            echo "sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.xml:$SBOM_XML_HASH" >> hashes.txt
+          fi
+
+          # Generate hashes for image-level SBOM files if they exist
+          if [ -f "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json" ]; then
+            if [[ "${{ runner.os }}" == "Windows" ]]; then
+              IMAGE_SBOM_HASH_OUTPUT=$(certutil -hashfile "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json" SHA256)
+              IMAGE_SBOM_HASH=$(echo "$IMAGE_SBOM_HASH_OUTPUT" | sed -n '2p' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+            elif [[ "${{ runner.os }}" == "macOS" ]]; then
+              IMAGE_SBOM_HASH=$(shasum -a 256 "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json" | awk '{print $1}')
+            else
+              IMAGE_SBOM_HASH=$(sha256sum "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json" | awk '{print $1}')
+            fi
+            echo "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json:$IMAGE_SBOM_HASH" >> hashes.txt
           fi
 
           # Create base64 encoded hash for SLSA (encoded_hash artifact_name format)
@@ -262,7 +307,7 @@ jobs:
       - name: Prepare SBOM files for upload
         shell: bash
         run: |
-          # Copy SBOM files with platform-specific names using same fallback detection logic
+          # Copy build-time SBOM files with platform-specific names using same fallback detection logic
           if [ "${{ matrix.platform }}" = "win32" ]; then
             # Check for SBOM files in the default location first
             if [ -f "/c/build-workspace/scopes/apps/scopes/build/reports/bom.json" ]; then
@@ -273,7 +318,7 @@ jobs:
               SBOM_JSON_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/cyclonedx/bom.json"
               SBOM_XML_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/cyclonedx/bom.xml"
             else
-              echo "Warning: SBOM files not found in expected locations"
+              echo "Warning: Build-time SBOM files not found in expected locations"
               SBOM_JSON_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/bom.json"
               SBOM_XML_PATH="/c/build-workspace/scopes/apps/scopes/build/reports/bom.xml"
             fi
@@ -287,18 +332,28 @@ jobs:
               SBOM_JSON_PATH="apps/scopes/build/reports/cyclonedx/bom.json"
               SBOM_XML_PATH="apps/scopes/build/reports/cyclonedx/bom.xml"
             else
-              echo "Warning: SBOM files not found in expected locations"
+              echo "Warning: Build-time SBOM files not found in expected locations"
               SBOM_JSON_PATH="apps/scopes/build/reports/bom.json"
               SBOM_XML_PATH="apps/scopes/build/reports/bom.xml"
             fi
           fi
 
+          # Copy build-time SBOM files with new naming convention
           if [ -f "$SBOM_JSON_PATH" ]; then
-            cp "$SBOM_JSON_PATH" "sbom-${{ matrix.platform }}-${{ matrix.arch }}.json"
+            cp "$SBOM_JSON_PATH" "sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.json"
+            echo "Copied build-time SBOM JSON: $(ls -la sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.json)"
           fi
 
           if [ -f "$SBOM_XML_PATH" ]; then
-            cp "$SBOM_XML_PATH" "sbom-${{ matrix.platform }}-${{ matrix.arch }}.xml"
+            cp "$SBOM_XML_PATH" "sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.xml"
+            echo "Copied build-time SBOM XML: $(ls -la sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.xml)"
+          fi
+
+          # Image-level SBOM files are already in the correct location with correct names
+          if [ -f "sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json" ]; then
+            echo "Image-level SBOM available (Syft): $(ls -la sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json)"
+          else
+            echo "No binary-level SBOM available"
           fi
 
       - name: Upload SBOM artifacts
@@ -306,8 +361,9 @@ jobs:
         with:
           name: sbom-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
-            sbom-${{ matrix.platform }}-${{ matrix.arch }}.json
-            sbom-${{ matrix.platform }}-${{ matrix.arch }}.xml
+            sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.json
+            sbom-build-${{ matrix.platform }}-${{ matrix.arch }}.xml
+            sbom-image-${{ matrix.platform }}-${{ matrix.arch }}.cyclonedx.json
 
 
       - name: Upload hash artifact
@@ -461,9 +517,10 @@ jobs:
             find ../provenance -name "*.intoto.jsonl" -type f -exec cp {} verification/multiple.intoto.jsonl \;
           fi
           
-          # Copy SBOM files
-          find ../sbom-artifacts -name "sbom-*.json" -type f -exec cp {} sbom/ \;
-          find ../sbom-artifacts -name "sbom-*.xml" -type f -exec cp {} sbom/ \;
+          # Copy SBOM files (both build-time and image-level)
+          find ../sbom-artifacts -name "sbom-build-*.json" -type f -exec cp {} sbom/ \;
+          find ../sbom-artifacts -name "sbom-build-*.xml" -type f -exec cp {} sbom/ \;
+          find ../sbom-artifacts -name "sbom-image-*.cyclonedx.json" -type f -exec cp {} sbom/ \;
           
           # Copy installation scripts and documentation
           cp ../install/offline/README.md .
@@ -720,9 +777,10 @@ jobs:
           # Upload hash files
           find artifacts -name "binary-hash-*.txt" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
 
-          # Upload SBOM files
-          find sbom-artifacts -name "sbom-*.json" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
-          find sbom-artifacts -name "sbom-*.xml" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
+          # Upload SBOM files (both build-time and image-level)
+          find sbom-artifacts -name "sbom-build-*.json" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
+          find sbom-artifacts -name "sbom-build-*.xml" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
+          find sbom-artifacts -name "sbom-image-*.cyclonedx.json" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
 
           # Upload distribution packages
           find distribution-packages -name "scopes-*-dist.tar.gz" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ Practical guides for accomplishing specific tasks and solving problems.
 
 - [Using Aliases](./guides/using-aliases.md) - Best practices for alias management
 - [Migrating to Aliases](./guides/migrating-to-aliases.md) - Transition from other systems
+- [SBOM Types Guide](./guides/sbom-types-guide.md) - Understanding build-time vs image-level SBOMs
+- [SBOM Verification](./guides/sbom-verification.md) - Security analysis with Software Bill of Materials
 - [Use Case Style Guide](./guides/use-case-style-guide.md) - Guidelines for implementing use cases
 
 ### 📋 [Reference](./reference/)

--- a/docs/explanation/automated-release-process.md
+++ b/docs/explanation/automated-release-process.md
@@ -60,9 +60,9 @@ graph TB
         direction TB
         A[📥 Checkout Code] --> B[⚙️ Setup Environment<br/>GraalVM + Gradle]
         B --> C[🏷️ Extract Version<br/>from Tag/Input]
-        C --> D[📋 Generate Source SBOM<br/>CycloneDX from Dependencies]
+        C --> D[📋 Generate Build-time SBOM<br/>CycloneDX from Gradle]
         D --> E[🔨 Native Compile<br/>Platform Binary]
-        E --> F[🔍 Generate Binary SBOM<br/>Syft Scanner]
+        E --> F[🔍 Extract Binary SBOM<br/>Syft binary analysis]
         F --> G[🛡️ Vulnerability Scan<br/>Grype (SARIF + JSON)]
         G --> H[#️⃣ Generate SHA-256<br/>All Artifact Hashes]
         H --> I[📤 Upload Artifacts<br/>Binary + SBOMs + Scan Results]
@@ -85,13 +85,13 @@ graph TB
     subgraph Download ["📦 Artifact Collection"]
         direction TB
         GetBin[📥 Download Binaries<br/>All Platforms]
-        GetSrcSBOM[📥 Download Source SBOMs<br/>CycloneDX Format]
+        GetBuildSBOM[📥 Download Build-time SBOMs<br/>CycloneDX from Gradle]
     end
     
     subgraph Scanning ["🔍 Security Analysis"]
         direction TB
         GrypeVuln[🛡️ Grype Vulnerability Scan<br/>JSON + SARIF Export]
-        SyftSBOM[📋 Syft Binary SBOM<br/>CycloneDX Generation]
+        ImageSBOM[📋 Binary SBOM<br/>Syft binary analysis]
         VerifyIntegrity[🔐 Binary Integrity Check<br/>SHA-256 Verification]
     end
     
@@ -153,8 +153,8 @@ graph TB
     subgraph Downloads ["📦 Artifact Collection"]
         direction TB
         GetBinaries[📥 Download Binaries<br/>All Platforms]
-        GetSourceSBOM[📥 Download Source SBOMs<br/>CycloneDX from Dependencies]
-        GetBinarySBOM[📥 Download Binary SBOMs<br/>Syft Generated]
+        GetBuildSBOM[📥 Download Build-time SBOMs<br/>CycloneDX from Gradle]
+        GetImageSBOM[📥 Download Binary SBOMs<br/>Syft binary analysis]
         GetScanResults[📥 Download Vulnerability<br/>Scan Results (JSON + SARIF)]
         GetProvenance[📥 Download SLSA<br/>Provenance Files]
     end
@@ -209,7 +209,7 @@ Pull requests and commits are automatically categorized using labels defined in 
 Each release automatically includes:
 
 - **Verification Instructions**: Quick one-liner installation with verification
-- **Dual-Level SBOM**: Source-level (dependencies) and binary-level (compiled artifacts) Software Bill of Materials
+- **Dual-Level SBOM**: Build-time (Gradle dependencies) and image-level (final binary components) Software Bill of Materials
 - **Vulnerability Assessment**: Grype security scan results integrated with GitHub Security tab
 - **SLSA Provenance**: Level 3 compliance with cryptographic attestations
 - **Documentation Links**: Links to security guides and verification procedures

--- a/docs/guides/sbom-types-guide.md
+++ b/docs/guides/sbom-types-guide.md
@@ -1,0 +1,167 @@
+# SBOM Types Guide
+
+This guide explains the different types of Software Bill of Materials (SBOMs) generated for Scopes releases and their intended use cases.
+
+## Overview
+
+Scopes generates two complementary types of SBOMs to provide comprehensive supply chain transparency:
+
+1. **Build-time SBOM** - Generated from Gradle build process
+2. **Binary SBOM** - Generated from final native binary using Syft
+
+## SBOM Types
+
+### Build-time SBOM
+
+**Files**: `sbom-build-{platform}-{arch}.json`, `sbom-build-{platform}-{arch}.xml`
+
+Generated using CycloneDX Gradle plugin during the build process.
+
+**Contents**:
+- Java dependencies declared in Gradle
+- Build-time artifacts and libraries
+- Maven/Gradle dependency tree
+- Metadata from `pom.xml` and `build.gradle.kts` files
+
+**Use Cases**:
+- License compliance analysis
+- Vulnerability scanning of declared dependencies
+- Build environment auditing
+- Supply chain risk assessment
+
+**Limitations**:
+- May include dependencies that are optimized out during native compilation
+- Does not reflect the final native binary composition
+- Cannot detect runtime-only or dynamically linked components
+
+### Binary SBOM
+
+**Files**: `sbom-image-{platform}-{arch}.cyclonedx.json`
+
+Generated using Syft binary analysis tool from the final compiled native binary.
+
+**Contents**:
+- Binary analysis of native executable
+- Detected libraries and dependencies within the binary
+- File signatures and package metadata
+- Platform-specific native dependencies
+- Components actually included in the final native binary
+
+**Use Cases**:
+- Final binary composition analysis
+- Runtime vulnerability assessment
+- Compliance verification for distributed binaries
+- Security scanning of actual deployed artifacts
+- Production security analysis
+
+**Advantages**:
+- Reflects the actual binary content after GraalVM optimizations
+- Cross-platform binary analysis
+- Industry-standard CycloneDX format
+- Open-source tool with active community support
+- No licensing requirements
+
+## Verification
+
+All SBOM types can be verified using the provided verification scripts:
+
+### Linux/macOS
+```bash
+./install/verify-release.sh --verify-sbom --version v1.0.0 --download
+```
+
+### Windows PowerShell
+```powershell
+.\install\Verify-Release.ps1 -VerifySBOM -Version v1.0.0 -AutoDownload
+```
+
+### Manual Verification
+
+#### CycloneDX Validation
+```bash
+# Install CycloneDX CLI
+npm install -g @cyclonedx/cli
+
+# Validate build-time SBOM
+cyclonedx validate sbom-build-linux-x64.json
+
+# Validate binary SBOM  
+cyclonedx validate sbom-image-linux-x64.cyclonedx.json
+```
+
+#### Hash Verification
+SHA256 hashes for all SBOM files are included in release assets:
+- Check `binary-hash-{platform}-{arch}.txt` files
+- Compare against calculated hashes
+
+## Integration Examples
+
+### Dependency-Track Integration
+```bash
+# Upload build-time SBOM
+curl -X POST "http://dtrack-server/api/v1/bom" \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d @sbom-build-linux-x64.json
+
+# Upload binary SBOM for runtime analysis
+curl -X POST "http://dtrack-server/api/v1/bom" \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d @sbom-image-linux-x64.cyclonedx.json
+```
+
+### Vulnerability Scanning
+```bash
+# Scan with Grype
+grype sbom:sbom-build-linux-x64.json
+grype sbom:sbom-image-linux-x64.cyclonedx.json
+
+# Scan with Syft
+syft scan sbom-build-linux-x64.json
+syft scan sbom-image-linux-x64.cyclonedx.json
+```
+
+## Best Practices
+
+### For Development Teams
+- Use **build-time SBOM** for:
+  - License compliance during development
+  - Dependency management and updates
+  - Build process auditing
+
+- Use **binary SBOM** for:
+  - Final security assessment before release
+  - Runtime vulnerability analysis
+  - Customer compliance requirements
+
+### For Security Teams
+- Analyze both SBOM types for complete coverage
+- Prioritize binary SBOM for production security scanning
+- Use build-time SBOM for development pipeline security
+
+### For Compliance Officers
+- Binary SBOM provides the most accurate compliance picture
+- Build-time SBOM useful for development process compliance
+- Both SBOMs together provide comprehensive audit trail
+
+## Troubleshooting
+
+### SBOM Validation Failures
+- **Cause**: Malformed JSON or missing required fields
+- **Solution**: Re-download from official releases or regenerate
+
+### Hash Mismatches
+- **Cause**: File corruption during download or generation
+- **Solution**: Re-download files and verify against official hashes
+
+### Missing Binary SBOM
+- **Cause**: Syft tool not available during build
+- **Solution**: Verify Syft installation in CI environment
+
+## References
+
+- [CycloneDX Specification](https://cyclonedx.org/)
+- [SPDX Specification](https://spdx.dev/)
+- [Syft SBOM Generator](https://github.com/anchore/syft)
+- [SLSA Provenance Guide](../security-verification.md)


### PR DESCRIPTION
## Summary
- Removed all Oracle GraalVM dependencies and references
- Replaced Oracle-specific native-image-inspect with Syft for binary SBOM generation  
- Simplified CI/CD pipeline by removing conditional logic

## Test plan
- [ ] CI workflow runs successfully with Community GraalVM
- [ ] Syft generates binary SBOMs correctly for all platforms
- [ ] Verification scripts work with new SBOM structure
- [ ] Documentation accurately reflects the changes

## Context
As requested by the user, this PR removes Oracle GraalVM dependencies since the project uses Community GraalVM. The native-image-inspect tool is only available in Oracle GraalVM (paid product), so we now use Syft as the standard method for binary SBOM generation.

## Changes
1. **CI Workflow**: 
   - Added Syft installation
   - Removed Oracle GraalVM specific logic
   - Simplified SBOM generation process

2. **Verification Scripts**:
   - Updated both bash and PowerShell scripts
   - Removed Syft as "fallback" - it's now the primary method
   - Maintained backward compatibility with file naming

3. **Documentation**:
   - Completely rewrote SBOM Types Guide
   - Updated verification guide
   - Updated workflow documentation

## Benefits
- ✅ No licensing requirements
- ✅ Works with Community GraalVM  
- ✅ Simpler, more maintainable pipeline
- ✅ Consistent SBOM generation across all environments
- ✅ Industry-standard CycloneDX format maintained

🤖 Generated with [Claude Code](https://claude.ai/code)