### PR TITLE
refactor: Apply Either pattern for functional DDD error handling

### DIFF
--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/command/handler/context/DeleteContextViewHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/command/handler/context/DeleteContextViewHandler.kt
@@ -40,7 +40,7 @@ class DeleteContextViewHandler(
                 )
 
             // Check if this context is currently active
-            val currentContext = activeContextService.getCurrentContext()
+            val currentContext = activeContextService.getCurrentContext().mapLeft { it as ScopesError }.bind()
             if (currentContext != null && currentContext.key.value == command.key) {
                 raise(
                     ScopesError.ValidationFailed(

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/ActiveContextRepositoryImpl.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/ActiveContextRepositoryImpl.kt
@@ -76,7 +76,7 @@ class ActiveContextRepositoryImpl(private val database: ScopeManagementDatabase)
             ensureInitialized().bind()
             try {
                 val result = database.activeContextQueries.getActiveContext().executeAsOneOrNull()
-                result?.let { activeContextToContextView(it) }
+                result?.let { activeContextToContextView(it).bind() } ?: null
             } catch (e: Exception) {
                 raise(
                     PersistenceError.StorageUnavailable(
@@ -145,31 +145,55 @@ class ActiveContextRepositoryImpl(private val database: ScopeManagementDatabase)
         }
     }
 
-    private fun rowToContextView(row: Context_views): ContextView {
-        val id = ContextViewId.create(row.id).fold(
-            ifLeft = { error("Invalid id in database: $it") },
-            ifRight = { it },
-        )
-        val key = ContextViewKey.create(row.key).fold(
-            ifLeft = { error("Invalid key in database: $it") },
-            ifRight = { it },
-        )
-        val name = ContextViewName.create(row.name).fold(
-            ifLeft = { error("Invalid name in database: $it") },
-            ifRight = { it },
-        )
-        val description = row.description?.let { desc ->
-            ContextViewDescription.create(desc).fold(
-                ifLeft = { error("Invalid description in database: $it") },
-                ifRight = { it },
+    private fun rowToContextView(row: Context_views): Either<PersistenceError, ContextView> = either {
+        val id = ContextViewId.create(row.id).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid id in database: $validationError",
             )
+        }.bind()
+        
+        val key = ContextViewKey.create(row.key).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid key in database: $validationError",
+            )
+        }.bind()
+        
+        val name = ContextViewName.create(row.name).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid name in database: $validationError",
+            )
+        }.bind()
+        
+        val description = row.description?.let { desc ->
+            ContextViewDescription.create(desc).mapLeft { validationError ->
+                PersistenceError.DataCorruption(
+                    occurredAt = Clock.System.now(),
+                    entityType = "ContextView",
+                    entityId = row.id,
+                    reason = "Invalid description in database: $validationError",
+                )
+            }.bind()
         }
-        val filter = ContextViewFilter.create(row.filter).fold(
-            ifLeft = { error("Invalid filter in database: $it") },
-            ifRight = { it },
-        )
+        
+        val filter = ContextViewFilter.create(row.filter).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid filter in database: $validationError",
+            )
+        }.bind()
 
-        return ContextView(
+        ContextView(
             id = id,
             key = key,
             name = name,
@@ -180,7 +204,7 @@ class ActiveContextRepositoryImpl(private val database: ScopeManagementDatabase)
         )
     }
 
-    private fun activeContextToContextView(row: GetActiveContext): ContextView? {
+    private fun activeContextToContextView(row: GetActiveContext): Either<PersistenceError, ContextView?> = either {
         // All fields except id can be null due to LEFT JOIN
         if (row.key == null ||
             row.name == null ||
@@ -188,33 +212,57 @@ class ActiveContextRepositoryImpl(private val database: ScopeManagementDatabase)
             row.created_at == null ||
             row.updated_at == null
         ) {
-            return null
+            return@either null
         }
 
-        val id = ContextViewId.create(row.id).fold(
-            ifLeft = { error("Invalid id in database: $it") },
-            ifRight = { it },
-        )
-        val key = ContextViewKey.create(row.key).fold(
-            ifLeft = { error("Invalid key in database: $it") },
-            ifRight = { it },
-        )
-        val name = ContextViewName.create(row.name).fold(
-            ifLeft = { error("Invalid name in database: $it") },
-            ifRight = { it },
-        )
-        val description = row.description?.let { desc ->
-            ContextViewDescription.create(desc).fold(
-                ifLeft = { error("Invalid description in database: $it") },
-                ifRight = { it },
+        val id = ContextViewId.create(row.id).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid id in database: $validationError",
             )
+        }.bind()
+        
+        val key = ContextViewKey.create(row.key).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid key in database: $validationError",
+            )
+        }.bind()
+        
+        val name = ContextViewName.create(row.name).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid name in database: $validationError",
+            )
+        }.bind()
+        
+        val description = row.description?.let { desc ->
+            ContextViewDescription.create(desc).mapLeft { validationError ->
+                PersistenceError.DataCorruption(
+                    occurredAt = Clock.System.now(),
+                    entityType = "ContextView",
+                    entityId = row.id,
+                    reason = "Invalid description in database: $validationError",
+                )
+            }.bind()
         }
-        val filter = ContextViewFilter.create(row.filter).fold(
-            ifLeft = { error("Invalid filter in database: $it") },
-            ifRight = { it },
-        )
+        
+        val filter = ContextViewFilter.create(row.filter).mapLeft { validationError ->
+            PersistenceError.DataCorruption(
+                occurredAt = Clock.System.now(),
+                entityType = "ContextView",
+                entityId = row.id,
+                reason = "Invalid filter in database: $validationError",
+            )
+        }.bind()
 
-        return ContextView(
+        ContextView(
             id = id,
             key = key,
             name = name,


### PR DESCRIPTION
## Summary

This PR refactors the codebase to follow functional DDD principles by replacing runtime exceptions with type-safe Either patterns for error handling.

## Problem

The codebase had several methods that used `error()` to throw runtime exceptions when encountering invalid data from the database. This approach:
- Could cause unexpected crashes in production
- Lost error context and recovery options
- Violated functional programming principles

## Solution

Implemented Arrow's Either pattern throughout the data transformation pipeline:

### 1. Infrastructure Layer Changes

**SqlDelightScopeRepository.kt**
```kotlin
// Before: Runtime exception on invalid data
private fun rowToScope(row: Scopes): Scope {
    val scopeId = ScopeId.create(row.id).fold(
        ifLeft = { error("Invalid scope id: $it") },  // 💥 Crashes
        ifRight = { it }
    )
    // ...
}

// After: Type-safe error propagation
private fun rowToScope(row: Scopes): Either<PersistenceError, Scope> = either {
    val scopeId = ScopeId.create(row.id).mapLeft { validationError ->
        PersistenceError.DataCorruption(
            occurredAt = Clock.System.now(),
            operation = "rowToScope",
            cause = RuntimeException("Invalid scope id: $validationError")
        )
    }.bind()
    // ...
}
```

**ActiveContextRepositoryImpl.kt**
- Similar transformation for `rowToContextView()` and `activeContextToContextView()`

### 2. Application Layer Changes

**ActiveContextService.kt**
```kotlin
// Before: Error information lost
suspend fun getCurrentContext(): ContextView? = 
    activeContextRepository.getActiveContext()
        .fold(
            ifLeft = { null },  // Error context lost
            ifRight = { it }
        )

// After: Error context preserved
suspend fun getCurrentContext(): Either<ApplicationError, ContextView?> = 
    activeContextRepository.getActiveContext().mapLeft { error ->
        // Proper error mapping
    }
```

## Breaking Changes

⚠️ **ActiveContextService.getCurrentContext()** now returns `Either<ApplicationError, ContextView?>` instead of `ContextView?`

Affected callers have been updated to handle the new return type using `.bind()` within either blocks.

## Benefits

✅ **Type Safety**: Compile-time verification of error handling
✅ **Error Context**: Full error information preserved through the call chain
✅ **Functional Purity**: No side effects from unexpected exceptions
✅ **Graceful Degradation**: System can recover from data corruption errors

## Testing

- [x] Compilation successful
- [x] Architecture tests pass (Konsist)
- [x] All affected methods properly handle Either types

## Checklist

- [x] Code follows functional DDD principles
- [x] Error handling is consistent across layers
- [x] Breaking changes are documented
- [x] Tests have been updated where necessary

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>