### PR TITLE
fix: Critical MCP module improvements for production stability

### DIFF
--- a/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/resources/handlers/TreeJsonResourceHandler.kt
+++ b/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/resources/handlers/TreeJsonResourceHandler.kt
@@ -14,7 +14,6 @@ import io.modelcontextprotocol.kotlin.sdk.TextResourceContents
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.serialization.json.*
 
@@ -109,7 +108,7 @@ class TreeJsonResourceHandler : ResourceHandler {
     private class TreeNodeBuilder(private val ports: Ports, private val services: Services, private val maxDepth: Int) {
         var nodeCount = 0
         val maxNodes = 1000
-        var latestUpdatedAt: Instant = Clock.System.now()
+        var latestUpdatedAt: Instant = Instant.DISTANT_PAST
 
         suspend fun buildScopeNode(alias: String, currentDepth: Int): JsonObject? {
             currentCoroutineContext().ensureActive()

--- a/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/DefaultIdempotencyService.kt
+++ b/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/DefaultIdempotencyService.kt
@@ -34,12 +34,14 @@ internal class DefaultIdempotencyService(
 
     companion object {
         private val IDEMPOTENCY_KEY_PATTERN = Regex("^[A-Za-z0-9_-]{8,128}$")
+
+        private fun isValidKey(key: String): Boolean = key.matches(IDEMPOTENCY_KEY_PATTERN)
     }
 
     override suspend fun checkIdempotency(toolName: String, arguments: Map<String, JsonElement>, idempotencyKey: String?): CallToolResult? {
         val effectiveKey = idempotencyKey ?: return null
 
-        if (!effectiveKey.matches(IDEMPOTENCY_KEY_PATTERN)) {
+        if (!isValidKey(effectiveKey)) {
             return CallToolResult(
                 content = listOf(TextContent(text = "Invalid idempotency key format")),
                 isError = true,
@@ -82,7 +84,7 @@ internal class DefaultIdempotencyService(
         val effectiveKey = idempotencyKey ?: return
 
         // Validate the idempotency key using the same logic as checkIdempotency
-        if (!effectiveKey.matches(IDEMPOTENCY_KEY_PATTERN)) {
+        if (!isValidKey(effectiveKey)) {
             // Invalid key - return early without storing anything
             return
         }

--- a/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/DefaultIdempotencyService.kt
+++ b/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/DefaultIdempotencyService.kt
@@ -32,10 +32,18 @@ internal class DefaultIdempotencyService(
     private val idempotencyStore = mutableMapOf<String, StoredResult>()
     private val mutex = Mutex()
 
+    companion object {
+        /**
+         * Validates that an idempotency key matches the required pattern.
+         * Uses the centralized pattern from IdempotencyService interface.
+         */
+        private fun isValidKey(key: String): Boolean = key.matches(IdempotencyService.IDEMPOTENCY_KEY_PATTERN)
+    }
+
     override suspend fun checkIdempotency(toolName: String, arguments: Map<String, JsonElement>, idempotencyKey: String?): CallToolResult? {
         val effectiveKey = idempotencyKey ?: return null
 
-        if (!effectiveKey.matches(IdempotencyService.IDEMPOTENCY_KEY_PATTERN)) {
+        if (!isValidKey(effectiveKey)) {
             return CallToolResult(
                 content = listOf(TextContent(text = "Invalid idempotency key format")),
                 isError = true,
@@ -78,7 +86,7 @@ internal class DefaultIdempotencyService(
         val effectiveKey = idempotencyKey ?: return
 
         // Validate the idempotency key using the same logic as checkIdempotency
-        if (!effectiveKey.matches(IdempotencyService.IDEMPOTENCY_KEY_PATTERN)) {
+        if (!isValidKey(effectiveKey)) {
             // Invalid key - return early without storing anything
             return
         }


### PR DESCRIPTION
## Summary
- Fix memory leak in DefaultIdempotencyService by validating keys before storage
- Improve error format to use human-readable messages with structured metadata
- Fix TreeJsonResourceHandler HTTP caching to use actual timestamps

## Details

### 1. Memory Leak Fix (DefaultIdempotencyService)
Previously, invalid idempotency keys were stored in the cache but later rejected by `checkIdempotency`, creating unretrievable entries. Now validation is performed before storage to prevent memory leaks.

### 2. Error Format Improvement (DefaultIdempotencyService)
Changed error responses from JSON payload in content field to human-readable messages with structured data in the `_meta` field for better user experience while maintaining machine readability.

### 3. HTTP Caching Fix (TreeJsonResourceHandler)
Replaced `Clock.System.now()` with `Instant.DISTANT_PAST` for initial timestamp to ensure proper HTTP cache validation based on actual scope modification times.

## Test plan
- [x] Build passes with all changes
- [x] Spotless formatting applied
- [x] Konsist architecture tests pass
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Structured, user-friendly error responses when an invalid idempotency key is provided.

- Bug Fixes
  - lastModified now reflects the latest update across all visited items in tree views.
  - Invalid idempotency keys are rejected early and are no longer stored.

- Improvements
  - More consistent error metadata for invalid idempotency keys, aiding debugging and client handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->