### PR TITLE
Refactor error handling and fix SonarQube quality gate failures

### DIFF
--- a/contexts/event-store/application/src/main/kotlin/io/github/kamiazya/scopes/eventstore/application/adapter/EventStoreCommandPortAdapter.kt
+++ b/contexts/event-store/application/src/main/kotlin/io/github/kamiazya/scopes/eventstore/application/adapter/EventStoreCommandPortAdapter.kt
@@ -18,7 +18,7 @@ class EventStoreCommandPortAdapter(private val storeEventHandler: StoreEventHand
     override suspend fun createEvent(command: StoreEventCommand): Either<EventStoreContractError, Unit> {
         // Deserialize the event data
         return eventSerializer.deserialize(command.eventType, command.eventData)
-            .mapLeft { error ->
+            .mapLeft { _ ->
                 EventStoreContractError.EventStorageError(
                     aggregateId = command.aggregateId,
                     eventType = command.eventType,
@@ -31,7 +31,7 @@ class EventStoreCommandPortAdapter(private val storeEventHandler: StoreEventHand
                 storeEventHandler(
                     AppStoreEventCommand(event = domainEvent),
                 )
-                    .mapLeft { error ->
+                    .mapLeft { _ ->
                         EventStoreContractError.EventStorageError(
                             aggregateId = command.aggregateId,
                             eventType = command.eventType,

--- a/contexts/event-store/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/eventstore/infrastructure/serializer/JsonEventSerializer.kt
+++ b/contexts/event-store/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/eventstore/infrastructure/serializer/JsonEventSerializer.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
-import kotlin.reflect.KClass
 
 /**
  * JSON-based implementation of EventSerializer.
@@ -78,8 +77,5 @@ class JsonEventSerializer(
      * Get the stable type identifier for a domain event.
      * This is used by the repository when persisting events.
      */
-    fun getEventType(event: DomainEvent): String {
-        @Suppress("UNCHECKED_CAST")
-        return eventTypeMapping.getTypeId(event::class as KClass<out DomainEvent>)
-    }
+    fun getEventType(event: DomainEvent): String = eventTypeMapping.getTypeId(event::class)
 }

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/command/handler/SetCanonicalAliasHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/command/handler/SetCanonicalAliasHandler.kt
@@ -10,7 +10,9 @@ import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeInputErr
 import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeInputErrorPresenter
 import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeManagementApplicationError
 import io.github.kamiazya.scopes.scopemanagement.application.service.ScopeAliasApplicationService
+import io.github.kamiazya.scopes.scopemanagement.domain.entity.ScopeAlias
 import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.AliasName
+import io.github.kamiazya.scopes.scopemanagement.domain.valueobject.ScopeId
 
 /**
  * Handler for setting a canonical alias for a scope.
@@ -34,129 +36,19 @@ class SetCanonicalAliasHandler(
                 ),
             )
 
-            // Validate currentAlias
-            val currentAliasName = AliasName.create(command.currentAlias)
-                .mapLeft { error ->
-                    logger.error(
-                        "Invalid current alias name",
-                        mapOf(
-                            "currentAlias" to command.currentAlias,
-                            "error" to error.toString(),
-                        ),
-                    )
-                    when (error) {
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.EmptyAlias ->
-                            ScopeInputError.AliasEmpty(command.currentAlias)
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.AliasTooShort ->
-                            ScopeInputError.AliasTooShort(command.currentAlias, error.minLength)
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.AliasTooLong ->
-                            ScopeInputError.AliasTooLong(command.currentAlias, error.maxLength)
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.InvalidAliasFormat ->
-                            ScopeInputError.AliasInvalidFormat(command.currentAlias, errorPresenter.presentAliasPattern(error.expectedPattern))
-                    }
-                }
-                .bind()
-
-            // Find current alias through application service
-            val currentAlias = scopeAliasService.findAliasByName(currentAliasName)
-                .mapLeft { error ->
-                    logger.error(
-                        "Failed to find current alias",
-                        mapOf(
-                            "currentAlias" to command.currentAlias,
-                            "error" to error.toString(),
-                        ),
-                    )
-                    error
-                }
-                .bind()
-
-            if (currentAlias == null) {
-                logger.error(
-                    "Current alias not found",
-                    mapOf("currentAlias" to command.currentAlias),
-                )
-                raise(ScopeInputError.AliasNotFound(command.currentAlias))
-            }
-
+            // Validate and find aliases
+            val currentAliasName = validateAliasName(command.currentAlias, "current").bind()
+            val currentAlias = findAlias(currentAliasName, command.currentAlias).bind()
             val scopeId = currentAlias.scopeId
 
-            // Validate newCanonicalAlias
-            val newCanonicalAliasName = AliasName.create(command.newCanonicalAlias)
-                .mapLeft { error ->
-                    logger.error(
-                        "Invalid new canonical alias name",
-                        mapOf(
-                            "newCanonicalAlias" to command.newCanonicalAlias,
-                            "error" to error.toString(),
-                        ),
-                    )
-                    when (error) {
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.EmptyAlias ->
-                            ScopeInputError.AliasEmpty(command.newCanonicalAlias)
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.AliasTooShort ->
-                            ScopeInputError.AliasTooShort(command.newCanonicalAlias, error.minLength)
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.AliasTooLong ->
-                            ScopeInputError.AliasTooLong(command.newCanonicalAlias, error.maxLength)
-                        is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.InvalidAliasFormat ->
-                            ScopeInputError.AliasInvalidFormat(command.newCanonicalAlias, errorPresenter.presentAliasPattern(error.expectedPattern))
-                    }
-                }
-                .bind()
+            val newCanonicalAliasName = validateAliasName(command.newCanonicalAlias, "new canonical").bind()
+            val newCanonicalAlias = findAlias(newCanonicalAliasName, command.newCanonicalAlias).bind()
 
-            // Find new canonical alias to verify it exists and get its scope ID
-            val newCanonicalAlias = scopeAliasService.findAliasByName(newCanonicalAliasName)
-                .mapLeft { error ->
-                    logger.error(
-                        "Failed to find new canonical alias",
-                        mapOf(
-                            "newCanonicalAlias" to command.newCanonicalAlias,
-                            "error" to error.toString(),
-                        ),
-                    )
-                    error
-                }
-                .bind()
+            // Verify aliases belong to same scope
+            verifySameScope(currentAlias, newCanonicalAlias, command).bind()
 
-            if (newCanonicalAlias == null) {
-                logger.error(
-                    "New canonical alias not found",
-                    mapOf("newCanonicalAlias" to command.newCanonicalAlias),
-                )
-                raise(ScopeInputError.AliasNotFound(command.newCanonicalAlias))
-            }
-
-            val newCanonicalAliasScopeId = newCanonicalAlias.scopeId
-
-            // Verify the new canonical alias belongs to the same scope
-            if (newCanonicalAliasScopeId != scopeId) {
-                logger.error(
-                    "New canonical alias belongs to different scope",
-                    mapOf(
-                        "currentAlias" to command.currentAlias,
-                        "newCanonicalAlias" to command.newCanonicalAlias,
-                        "currentAliasScope" to scopeId.value,
-                        "newCanonicalAliasScope" to newCanonicalAliasScopeId.value,
-                    ),
-                )
-                raise(ScopeInputError.InvalidAlias(command.newCanonicalAlias))
-            }
-
-            // Set as canonical (service handles the demotion logic and idempotency)
-            scopeAliasService.assignCanonicalAlias(scopeId, newCanonicalAliasName)
-                .mapLeft { error ->
-                    logger.error(
-                        "Failed to set canonical alias",
-                        mapOf(
-                            "currentAlias" to command.currentAlias,
-                            "newCanonicalAlias" to command.newCanonicalAlias,
-                            "scopeId" to scopeId.value,
-                            "error" to error.toString(),
-                        ),
-                    )
-                    error
-                }
-                .bind()
+            // Set as canonical
+            setCanonicalAlias(scopeId, newCanonicalAliasName, command).bind()
 
             logger.info(
                 "Successfully set canonical alias",
@@ -168,4 +60,97 @@ class SetCanonicalAliasHandler(
             )
         }
     }
+
+    private fun validateAliasName(alias: String, aliasType: String): Either<ScopeManagementApplicationError, AliasName> =
+        AliasName.create(alias).mapLeft { error ->
+            logger.error(
+                "Invalid $aliasType alias name",
+                mapOf(
+                    "${aliasType}Alias" to alias,
+                    "error" to error.toString(),
+                ),
+            )
+            mapAliasError(error, alias)
+        }
+
+    private fun mapAliasError(error: io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError, alias: String): ScopeInputError =
+        when (error) {
+            is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.EmptyAlias ->
+                ScopeInputError.AliasEmpty(alias)
+            is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.AliasTooShort ->
+                ScopeInputError.AliasTooShort(alias, error.minLength)
+            is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.AliasTooLong ->
+                ScopeInputError.AliasTooLong(alias, error.maxLength)
+            is io.github.kamiazya.scopes.scopemanagement.domain.error.ScopeInputError.AliasError.InvalidAliasFormat ->
+                ScopeInputError.AliasInvalidFormat(alias, errorPresenter.presentAliasPattern(error.expectedPattern))
+        }
+
+    private suspend fun findAlias(aliasName: AliasName, aliasString: String): Either<ScopeManagementApplicationError, ScopeAlias> = either {
+        val alias = scopeAliasService.findAliasByName(aliasName)
+            .mapLeft { error ->
+                logger.error(
+                    "Failed to find alias",
+                    mapOf(
+                        "alias" to aliasString,
+                        "error" to error.toString(),
+                    ),
+                )
+                error
+            }
+            .bind()
+
+        if (alias == null) {
+            logger.error(
+                "Alias not found",
+                mapOf("alias" to aliasString),
+            )
+            raise(ScopeInputError.AliasNotFound(aliasString))
+        }
+
+        alias
+    }
+
+    private fun verifySameScope(
+        currentAlias: ScopeAlias,
+        newCanonicalAlias: ScopeAlias,
+        command: SetCanonicalAliasCommand,
+    ): Either<ScopeManagementApplicationError, Unit> = either {
+        if (newCanonicalAlias.scopeId != currentAlias.scopeId) {
+            logger.error(
+                "New canonical alias belongs to different scope",
+                mapOf(
+                    "currentAlias" to command.currentAlias,
+                    "newCanonicalAlias" to command.newCanonicalAlias,
+                    "currentAliasScope" to currentAlias.scopeId.value,
+                    "newCanonicalAliasScope" to newCanonicalAlias.scopeId.value,
+                ),
+            )
+            raise(
+                ScopeInputError.AliasOfDifferentScope(
+                    alias = command.newCanonicalAlias,
+                    expectedScopeId = currentAlias.scopeId.value,
+                    actualScopeId = newCanonicalAlias.scopeId.value,
+                ),
+            )
+        }
+    }
+
+    private suspend fun setCanonicalAlias(
+        scopeId: ScopeId,
+        aliasName: AliasName,
+        command: SetCanonicalAliasCommand,
+    ): Either<ScopeManagementApplicationError, Unit> = scopeAliasService.assignCanonicalAlias(scopeId, aliasName)
+        .mapLeft { error ->
+            logger.error(
+                "Failed to set canonical alias",
+                mapOf(
+                    "currentAlias" to command.currentAlias,
+                    "newCanonicalAlias" to command.newCanonicalAlias,
+                    "scopeId" to scopeId.value,
+                    "error" to error.toString(),
+                ),
+            )
+            error
+        }
+        .map { Unit }
 }

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/command/handler/aspect/DeleteAspectDefinitionHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/command/handler/aspect/DeleteAspectDefinitionHandler.kt
@@ -32,7 +32,7 @@ class DeleteAspectDefinitionHandler(
 
                 // Check if definition exists
                 aspectDefinitionRepository.findByKey(aspectKey).fold(
-                    { error ->
+                    { _ ->
                         raise(
                             ScopesError.SystemError(
                                 errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ErrorMappingExtensions.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ErrorMappingExtensions.kt
@@ -164,23 +164,23 @@ fun DomainScopeInputError.toApplicationError(attemptedValue: String): ScopeManag
         )
 
     is DomainScopeInputError.AliasError.EmptyAlias ->
-        AppScopeInputError.AliasEmpty(attemptedValue = attemptedValue)
+        AppScopeInputError.AliasEmpty(alias = attemptedValue)
 
     is DomainScopeInputError.AliasError.AliasTooShort ->
         AppScopeInputError.AliasTooShort(
-            attemptedValue = attemptedValue,
+            alias = attemptedValue,
             minimumLength = this.minLength,
         )
 
     is DomainScopeInputError.AliasError.AliasTooLong ->
         AppScopeInputError.AliasTooLong(
-            attemptedValue = attemptedValue,
+            alias = attemptedValue,
             maximumLength = this.maxLength,
         )
 
     is DomainScopeInputError.AliasError.InvalidAliasFormat ->
         AppScopeInputError.AliasInvalidFormat(
-            attemptedValue = attemptedValue,
+            alias = attemptedValue,
             expectedPattern = scopeInputErrorPresenter.presentAliasPattern(this.expectedPattern),
         )
 }
@@ -222,7 +222,7 @@ fun DomainScopeAliasError.toApplicationError(): ScopeManagementApplicationError 
         AppScopeAliasError.AliasGenerationValidationFailed(
             scopeId = "scope-id",
             reason = this.reason,
-            attemptedValue = this.alias,
+            alias = this.alias,
         )
 
     is DomainScopeAliasError.DataInconsistencyError.AliasReferencesNonExistentScope ->

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ErrorMappingExtensions.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ErrorMappingExtensions.kt
@@ -124,62 +124,63 @@ fun ContextError.toApplicationError(): ScopeManagementApplicationError = when (t
 
 /**
  * Maps ScopeInputError to ApplicationError.ScopeInputError
+ * Note: This mapping loses the attempted value, which should be provided by the calling code
  */
-fun DomainScopeInputError.toApplicationError(): ScopeManagementApplicationError = when (this) {
+fun DomainScopeInputError.toApplicationError(attemptedValue: String): ScopeManagementApplicationError = when (this) {
     is DomainScopeInputError.IdError.EmptyId ->
-        AppScopeInputError.IdBlank("empty-id")
+        AppScopeInputError.IdBlank(attemptedValue = attemptedValue)
 
     is DomainScopeInputError.IdError.InvalidIdFormat ->
         AppScopeInputError.IdInvalidFormat(
-            attemptedValue = this.id,
+            attemptedValue = attemptedValue,
             expectedFormat = scopeInputErrorPresenter.presentIdFormat(this.expectedFormat),
         )
 
     is DomainScopeInputError.TitleError.EmptyTitle ->
-        AppScopeInputError.TitleEmpty("empty-title")
+        AppScopeInputError.TitleEmpty(attemptedValue = attemptedValue)
 
     is DomainScopeInputError.TitleError.TitleTooShort ->
         AppScopeInputError.TitleTooShort(
-            attemptedValue = "too-short",
+            attemptedValue = attemptedValue,
             minimumLength = this.minLength,
         )
 
     is DomainScopeInputError.TitleError.TitleTooLong ->
         AppScopeInputError.TitleTooLong(
-            attemptedValue = "too-long",
+            attemptedValue = attemptedValue,
             maximumLength = this.maxLength,
         )
 
     is DomainScopeInputError.TitleError.InvalidTitleFormat ->
         AppScopeInputError.TitleContainsProhibitedCharacters(
-            attemptedValue = this.title,
+            attemptedValue = attemptedValue,
             prohibitedCharacters = listOf('<', '>', '&', '"'),
         )
 
     is DomainScopeInputError.DescriptionError.DescriptionTooLong ->
         AppScopeInputError.DescriptionTooLong(
-            attemptedValue = "too-long",
+            attemptedValue = attemptedValue,
             maximumLength = this.maxLength,
         )
 
     is DomainScopeInputError.AliasError.EmptyAlias ->
-        AppScopeInputError.AliasEmpty("empty-alias")
+        AppScopeInputError.AliasEmpty(attemptedValue = attemptedValue)
 
     is DomainScopeInputError.AliasError.AliasTooShort ->
         AppScopeInputError.AliasTooShort(
-            attemptedValue = "too-short",
+            attemptedValue = attemptedValue,
             minimumLength = this.minLength,
         )
 
     is DomainScopeInputError.AliasError.AliasTooLong ->
         AppScopeInputError.AliasTooLong(
-            attemptedValue = "too-long",
+            attemptedValue = attemptedValue,
             maximumLength = this.maxLength,
         )
 
     is DomainScopeInputError.AliasError.InvalidAliasFormat ->
         AppScopeInputError.AliasInvalidFormat(
-            attemptedValue = this.alias,
+            attemptedValue = attemptedValue,
             expectedPattern = scopeInputErrorPresenter.presentAliasPattern(this.expectedPattern),
         )
 }
@@ -245,7 +246,7 @@ fun DomainScopeAliasError.toApplicationError(): ScopeManagementApplicationError 
 fun ScopesError.toGenericApplicationError(): ScopeManagementApplicationError = when (this) {
     is DomainPersistenceError -> this.toApplicationError()
     is ContextError -> this.toApplicationError()
-    is DomainScopeInputError -> this.toApplicationError()
+    is DomainScopeInputError -> this.toApplicationError("") // Empty string as fallback when attemptedValue is not available
     is DomainScopeAliasError -> this.toApplicationError()
 
     // Map hierarchy errors to appropriate application errors

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ScopeAliasError.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ScopeAliasError.kt
@@ -8,7 +8,7 @@ sealed class ScopeAliasError : ScopeManagementApplicationError() {
     data class AliasNotFound(val aliasName: String) : ScopeAliasError()
     data class CannotRemoveCanonicalAlias(val scopeId: String, val aliasName: String) : ScopeAliasError()
     data class AliasGenerationFailed(val scopeId: String, val retryCount: Int) : ScopeAliasError()
-    data class AliasGenerationValidationFailed(val scopeId: String, val reason: String, val attemptedValue: String) : ScopeAliasError()
+    data class AliasGenerationValidationFailed(val scopeId: String, val reason: String, val alias: String) : ScopeAliasError()
 
     /**
      * Data inconsistency errors representing broken data relationships.

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ScopeInputError.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ScopeInputError.kt
@@ -19,10 +19,10 @@ sealed class ScopeInputError : ScopeManagementApplicationError() {
     data class DescriptionTooLong(val attemptedValue: String, val maximumLength: Int) : ScopeInputError()
 
     // Alias related errors
-    data class AliasEmpty(val attemptedValue: String) : ScopeInputError()
-    data class AliasTooShort(val attemptedValue: String, val minimumLength: Int) : ScopeInputError()
-    data class AliasTooLong(val attemptedValue: String, val maximumLength: Int) : ScopeInputError()
-    data class AliasInvalidFormat(val attemptedValue: String, val expectedPattern: String) : ScopeInputError()
+    data class AliasEmpty(val alias: String) : ScopeInputError()
+    data class AliasTooShort(val alias: String, val minimumLength: Int) : ScopeInputError()
+    data class AliasTooLong(val alias: String, val maximumLength: Int) : ScopeInputError()
+    data class AliasInvalidFormat(val alias: String, val expectedPattern: String) : ScopeInputError()
 
     data class InvalidAlias(val alias: String) : ScopeInputError()
 

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ScopeInputError.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/error/ScopeInputError.kt
@@ -4,30 +4,35 @@ package io.github.kamiazya.scopes.scopemanagement.application.error
  * Errors related to scope input validation.
  */
 sealed class ScopeInputError : ScopeManagementApplicationError() {
+    // ID related errors
     data class IdBlank(val attemptedValue: String) : ScopeInputError()
     data class IdInvalidFormat(val attemptedValue: String, val expectedFormat: String = "ULID") : ScopeInputError()
 
+    // Title related errors
     data class TitleEmpty(val attemptedValue: String) : ScopeInputError()
     data class TitleTooShort(val attemptedValue: String, val minimumLength: Int) : ScopeInputError()
     data class TitleTooLong(val attemptedValue: String, val maximumLength: Int) : ScopeInputError()
-    data class TitleContainsProhibitedCharacters(val attemptedValue: String, val prohibitedCharacters: List<Char>) : ScopeInputError()
+    data class TitleContainsProhibitedCharacters(val attemptedValue: String, val prohibitedCharacters: List<Char> = listOf('<', '>', '&', '"')) :
+        ScopeInputError()
 
+    // Description related errors
     data class DescriptionTooLong(val attemptedValue: String, val maximumLength: Int) : ScopeInputError()
 
+    // Alias related errors
     data class AliasEmpty(val attemptedValue: String) : ScopeInputError()
     data class AliasTooShort(val attemptedValue: String, val minimumLength: Int) : ScopeInputError()
     data class AliasTooLong(val attemptedValue: String, val maximumLength: Int) : ScopeInputError()
     data class AliasInvalidFormat(val attemptedValue: String, val expectedPattern: String) : ScopeInputError()
 
-    data class InvalidAlias(val attemptedValue: String) : ScopeInputError()
+    data class InvalidAlias(val alias: String) : ScopeInputError()
 
-    data class AliasNotFound(val attemptedValue: String) : ScopeInputError()
+    data class AliasNotFound(val alias: String) : ScopeInputError()
 
-    data class AliasDuplicate(val attemptedValue: String) : ScopeInputError()
+    data class AliasDuplicate(val alias: String) : ScopeInputError()
 
-    data class CannotRemoveCanonicalAlias(val attemptedValue: String) : ScopeInputError()
+    data object CannotRemoveCanonicalAlias : ScopeInputError()
 
-    data class AliasOfDifferentScope(val attemptedValue: String) : ScopeInputError()
+    data class AliasOfDifferentScope(val alias: String, val expectedScopeId: String, val actualScopeId: String) : ScopeInputError()
 
-    data class InvalidParentId(val attemptedValue: String) : ScopeInputError()
+    data class InvalidParentId(val parentId: String) : ScopeInputError()
 }

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/projection/InMemoryScopeProjectionService.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/projection/InMemoryScopeProjectionService.kt
@@ -219,7 +219,7 @@ class InMemoryScopeProjectionService : ScopeProjectionService {
             // Create ScopeId from string for the error
             ScopeId.create(scopeId).fold(
                 { it.toGenericApplicationError().left() },
-                { validScopeId ->
+                { _ ->
                     ScopeManagementApplicationError.PersistenceError.NotFound(
                         entityType = "Scope",
                         entityId = scopeId,

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/handler/context/GetFilteredScopesHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/handler/context/GetFilteredScopesHandler.kt
@@ -53,7 +53,7 @@ class GetFilteredScopesHandler(
 
                     // Use specified context
                     contextViewRepository.findByKey(contextViewKey)
-                        .mapLeft { error ->
+                        .mapLeft { _ ->
                             ScopesError.SystemError(
                                 errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                                 service = "context-repository",
@@ -65,7 +65,7 @@ class GetFilteredScopesHandler(
                 else -> {
                     // Use active context if available
                     activeContextRepository.getActiveContext()
-                        .mapLeft { error ->
+                        .mapLeft { _ ->
                             ScopesError.SystemError(
                                 errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                                 service = "active-context-repository",
@@ -78,7 +78,7 @@ class GetFilteredScopesHandler(
 
             // Get all scopes with pagination
             val allScopes = scopeRepository.findAll(query.offset, query.limit)
-                .mapLeft { error ->
+                .mapLeft { _ ->
                     ScopesError.SystemError(
                         errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                         service = "scope-repository",
@@ -94,7 +94,7 @@ class GetFilteredScopesHandler(
             val filteredScopes = if (contextView != null) {
                 // Get aspect definitions for type-aware comparison
                 val aspectDefinitions = aspectDefinitionRepository.findAll()
-                    .mapLeft { error ->
+                    .mapLeft { _ ->
                         ScopesError.SystemError(
                             errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                             service = "aspect-repository",
@@ -106,7 +106,7 @@ class GetFilteredScopesHandler(
 
                 // Use the domain-rich filter method
                 val filtered = contextView.filterScopes(allScopes, aspectDefinitions, filterEvaluationService)
-                    .mapLeft { error ->
+                    .mapLeft { _ ->
                         ScopesError.SystemError(
                             errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                             service = "filter-evaluation",

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/handler/scope/FilterScopesWithQueryHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/handler/scope/FilterScopesWithQueryHandler.kt
@@ -60,7 +60,7 @@ class FilterScopesWithQueryHandler(
 
                 // Get all aspect definitions for type-aware comparison
                 val definitions = aspectDefinitionRepository.findAll()
-                    .mapLeft { error ->
+                    .mapLeft { _ ->
                         ScopesError.SystemError(
                             errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                             service = "aspect-repository",
@@ -80,7 +80,7 @@ class FilterScopesWithQueryHandler(
                             .mapLeft { it.toGenericApplicationError() }
                             .bind()
                         scopeRepository.findByParentId(parentScopeId, offset = 0, limit = 1000)
-                            .mapLeft { error ->
+                            .mapLeft { _ ->
                                 ScopesError.SystemError(
                                     errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                                     service = SCOPE_REPOSITORY_SERVICE,
@@ -95,7 +95,7 @@ class FilterScopesWithQueryHandler(
                     query.limit != 100 || query.offset > 0 -> {
                         // Use pagination - get all scopes with offset and limit
                         scopeRepository.findAll(query.offset, query.limit)
-                            .mapLeft { error ->
+                            .mapLeft { _ ->
                                 ScopesError.SystemError(
                                     errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                                     service = SCOPE_REPOSITORY_SERVICE,
@@ -111,7 +111,7 @@ class FilterScopesWithQueryHandler(
                     else -> {
                         // Default behavior - get root scopes only
                         scopeRepository.findAllRoot()
-                            .mapLeft { error ->
+                            .mapLeft { _ ->
                                 ScopesError.SystemError(
                                     errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                                     service = SCOPE_REPOSITORY_SERVICE,

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/handler/scope/ListAliasesHandler.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/query/handler/scope/ListAliasesHandler.kt
@@ -41,7 +41,7 @@ class ListAliasesHandler(
 
                 // Get the scope to verify it exists
                 scopeRepository.findById(scopeId)
-                    .mapLeft { error ->
+                    .mapLeft { _ ->
                         ScopesError.SystemError(
                             errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                             service = "scope-repository",
@@ -62,7 +62,7 @@ class ListAliasesHandler(
 
                 // Get all aliases for the scope
                 val aliases = scopeAliasRepository.findByScopeId(scopeId)
-                    .mapLeft { error ->
+                    .mapLeft { _ ->
                         ScopesError.SystemError(
                             errorType = ScopesError.SystemError.SystemErrorType.EXTERNAL_SERVICE_ERROR,
                             service = "alias-repository",

--- a/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/service/validation/AspectUsageValidationService.kt
+++ b/contexts/scope-management/application/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/application/service/validation/AspectUsageValidationService.kt
@@ -21,7 +21,7 @@ class AspectUsageValidationService(private val scopeRepository: ScopeRepository)
     suspend fun ensureNotInUse(aspectKey: AspectKey): Either<ScopeManagementApplicationError, Unit> = either {
         // Check if any scopes are using this aspect
         val count = scopeRepository.countByAspectKey(aspectKey).fold(
-            { error ->
+            { _ ->
                 raise(
                     ScopeManagementApplicationError.PersistenceError.StorageUnavailable(
                         operation = "count-aspect-usage",

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/aggregate/ScopeAggregate.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/aggregate/ScopeAggregate.kt
@@ -168,15 +168,16 @@ data class ScopeAggregate(
      * Ensures the scope exists and is not deleted.
      */
     fun updateTitle(title: String, now: Instant = Clock.System.now()): Either<ScopesError, ScopeAggregate> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
 
         val newTitle = ScopeTitle.create(title).bind()
-        if (scope!!.title == newTitle) {
+        if (currentScope.title == newTitle) {
             return@either this@ScopeAggregate
         }
 
@@ -186,8 +187,8 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = version.increment(),
-            scopeId = scope!!.id,
-            oldTitle = scope!!.title,
+            scopeId = currentScope.id,
+            oldTitle = currentScope.title,
             newTitle = newTitle,
         )
 
@@ -199,15 +200,16 @@ data class ScopeAggregate(
      * Returns pending events or empty list if no change needed.
      */
     fun decideUpdateTitle(title: String, now: Instant = Clock.System.now()): Either<ScopesError, List<EventEnvelope.Pending<ScopeEvent>>> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
 
         val newTitle = ScopeTitle.create(title).bind()
-        if (scope!!.title == newTitle) {
+        if (currentScope.title == newTitle) {
             return@either emptyList()
         }
 
@@ -217,8 +219,8 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = AggregateVersion.initial(), // Dummy version
-            scopeId = scope!!.id,
-            oldTitle = scope!!.title,
+            scopeId = currentScope.id,
+            oldTitle = currentScope.title,
             newTitle = newTitle,
         )
 
@@ -256,15 +258,16 @@ data class ScopeAggregate(
      * Updates the scope description after validation.
      */
     fun updateDescription(description: String?, now: Instant = Clock.System.now()): Either<ScopesError, ScopeAggregate> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
 
         val newDescription = ScopeDescription.create(description).bind()
-        if (scope!!.description == newDescription) {
+        if (currentScope.description == newDescription) {
             return@either this@ScopeAggregate
         }
 
@@ -274,8 +277,8 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = version.increment(),
-            scopeId = scope!!.id,
-            oldDescription = scope!!.description,
+            scopeId = currentScope.id,
+            oldDescription = currentScope.description,
             newDescription = newDescription,
         )
 
@@ -287,14 +290,15 @@ data class ScopeAggregate(
      * Validates hierarchy constraints before applying the change.
      */
     fun changeParent(newParentId: ScopeId?, now: Instant = Clock.System.now()): Either<ScopesError, ScopeAggregate> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
 
-        if (scope!!.parentId == newParentId) {
+        if (currentScope.parentId == newParentId) {
             return@either this@ScopeAggregate
         }
 
@@ -304,8 +308,8 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = version.increment(),
-            scopeId = scope!!.id,
-            oldParentId = scope!!.parentId,
+            scopeId = currentScope.id,
+            oldParentId = currentScope.parentId,
             newParentId = newParentId,
         )
 
@@ -317,11 +321,12 @@ data class ScopeAggregate(
      * Soft delete that marks the scope as deleted.
      */
     fun delete(now: Instant = Clock.System.now()): Either<ScopesError, ScopeAggregate> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
 
         val event = ScopeDeleted(
@@ -330,7 +335,7 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = version.increment(),
-            scopeId = scope!!.id,
+            scopeId = currentScope.id,
         )
 
         this@ScopeAggregate.raiseEvent(event)
@@ -341,14 +346,15 @@ data class ScopeAggregate(
      * Archived scopes are hidden but can be restored.
      */
     fun archive(now: Instant = Clock.System.now()): Either<ScopesError, ScopeAggregate> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
         ensure(!isArchived) {
-            ScopeError.AlreadyArchived(scope!!.id)
+            ScopeError.AlreadyArchived(currentScope.id)
         }
 
         val event = ScopeArchived(
@@ -357,7 +363,7 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = version.increment(),
-            scopeId = scope!!.id,
+            scopeId = currentScope.id,
             reason = null,
         )
 
@@ -368,14 +374,15 @@ data class ScopeAggregate(
      * Restores an archived scope.
      */
     fun restore(now: Instant = Clock.System.now()): Either<ScopesError, ScopeAggregate> = either {
-        ensureNotNull(scope) {
+        val currentScope = scope
+        ensureNotNull(currentScope) {
             ScopeError.NotFound(ScopeId.create(id.value.substringAfterLast("/")).bind())
         }
         ensure(!isDeleted) {
-            ScopeError.AlreadyDeleted(scope!!.id)
+            ScopeError.AlreadyDeleted(currentScope.id)
         }
         ensure(isArchived) {
-            ScopeError.NotArchived(scope!!.id)
+            ScopeError.NotArchived(currentScope.id)
         }
 
         val event = ScopeRestored(
@@ -384,7 +391,7 @@ data class ScopeAggregate(
             occurredAt = now,
 
             aggregateVersion = version.increment(),
-            scopeId = scope!!.id,
+            scopeId = currentScope.id,
         )
 
         this@ScopeAggregate.raiseEvent(event)

--- a/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/service/validation/AspectValueValidationService.kt
+++ b/contexts/scope-management/domain/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/domain/service/validation/AspectValueValidationService.kt
@@ -67,7 +67,7 @@ class AspectValueValidationService(private val strictValidation: Boolean = true,
                 }
             }
             is AspectType.Ordered -> {
-                val orderedType = definition.type as AspectType.Ordered
+                val orderedType = definition.type
                 if (!orderedType.allowedValues.contains(value)) {
                     ScopesError.ValidationFailed(
                         field = definition.key.value,

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ApplicationErrorMapper.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ApplicationErrorMapper.kt
@@ -66,25 +66,25 @@ class ApplicationErrorMapper(logger: Logger) : BaseErrorMapper<ScopeManagementAp
 
         // Alias validation errors
         is AppScopeInputError.AliasEmpty -> ScopeContractError.InputError.InvalidAlias(
-            alias = domainError.attemptedValue,
+            alias = domainError.alias,
             validationFailure = ScopeContractError.AliasValidationFailure.Empty,
         )
         is AppScopeInputError.AliasTooShort -> ScopeContractError.InputError.InvalidAlias(
-            alias = domainError.attemptedValue,
+            alias = domainError.alias,
             validationFailure = ScopeContractError.AliasValidationFailure.TooShort(
                 minimumLength = domainError.minimumLength,
-                actualLength = domainError.attemptedValue.length,
+                actualLength = domainError.alias.length,
             ),
         )
         is AppScopeInputError.AliasTooLong -> ScopeContractError.InputError.InvalidAlias(
-            alias = domainError.attemptedValue,
+            alias = domainError.alias,
             validationFailure = ScopeContractError.AliasValidationFailure.TooLong(
                 maximumLength = domainError.maximumLength,
-                actualLength = domainError.attemptedValue.length,
+                actualLength = domainError.alias.length,
             ),
         )
         is AppScopeInputError.AliasInvalidFormat -> ScopeContractError.InputError.InvalidAlias(
-            alias = domainError.attemptedValue,
+            alias = domainError.alias,
             validationFailure = ScopeContractError.AliasValidationFailure.InvalidFormat(
                 expectedPattern = domainError.expectedPattern,
             ),

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ApplicationErrorMapper.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ApplicationErrorMapper.kt
@@ -3,7 +3,12 @@ package io.github.kamiazya.scopes.scopemanagement.infrastructure.adapters
 import io.github.kamiazya.scopes.contracts.scopemanagement.errors.ScopeContractError
 import io.github.kamiazya.scopes.platform.application.error.BaseErrorMapper
 import io.github.kamiazya.scopes.platform.observability.logging.Logger
+import io.github.kamiazya.scopes.scopemanagement.application.error.ContextError
+import io.github.kamiazya.scopes.scopemanagement.application.error.CrossAggregateValidationError
+import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeAliasError
+import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeHierarchyApplicationError
 import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeManagementApplicationError
+import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeUniquenessError
 import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeInputError as AppScopeInputError
 
 /**
@@ -14,9 +19,7 @@ import io.github.kamiazya.scopes.scopemanagement.application.error.ScopeInputErr
  */
 class ApplicationErrorMapper(logger: Logger) : BaseErrorMapper<ScopeManagementApplicationError, ScopeContractError>(logger) {
     override fun mapToContractError(domainError: ScopeManagementApplicationError): ScopeContractError = when (domainError) {
-        is AppScopeInputError.AliasNotFound -> ScopeContractError.BusinessError.AliasNotFound(
-            alias = domainError.attemptedValue,
-        )
+        // ID validation errors
         is AppScopeInputError.IdBlank -> ScopeContractError.InputError.InvalidId(
             id = domainError.attemptedValue,
             expectedFormat = "Non-empty ULID format",
@@ -25,6 +28,8 @@ class ApplicationErrorMapper(logger: Logger) : BaseErrorMapper<ScopeManagementAp
             id = domainError.attemptedValue,
             expectedFormat = domainError.expectedFormat,
         )
+
+        // Title validation errors
         is AppScopeInputError.TitleEmpty -> ScopeContractError.InputError.InvalidTitle(
             title = domainError.attemptedValue,
             validationFailure = ScopeContractError.TitleValidationFailure.Empty,
@@ -49,12 +54,187 @@ class ApplicationErrorMapper(logger: Logger) : BaseErrorMapper<ScopeManagementAp
                 prohibitedCharacters = domainError.prohibitedCharacters,
             ),
         )
-        is AppScopeInputError.AliasDuplicate -> ScopeContractError.BusinessError.DuplicateAlias(
-            alias = domainError.attemptedValue,
+
+        // Description validation errors
+        is AppScopeInputError.DescriptionTooLong -> ScopeContractError.InputError.InvalidDescription(
+            descriptionText = domainError.attemptedValue,
+            validationFailure = ScopeContractError.DescriptionValidationFailure.TooLong(
+                maximumLength = domainError.maximumLength,
+                actualLength = domainError.attemptedValue.length,
+            ),
         )
-        else -> handleUnmappedError(
-            domainError,
-            ScopeContractError.SystemError.ServiceUnavailable(service = "scope-management"),
+
+        // Alias validation errors
+        is AppScopeInputError.AliasEmpty -> ScopeContractError.InputError.InvalidAlias(
+            alias = domainError.attemptedValue,
+            validationFailure = ScopeContractError.AliasValidationFailure.Empty,
+        )
+        is AppScopeInputError.AliasTooShort -> ScopeContractError.InputError.InvalidAlias(
+            alias = domainError.attemptedValue,
+            validationFailure = ScopeContractError.AliasValidationFailure.TooShort(
+                minimumLength = domainError.minimumLength,
+                actualLength = domainError.attemptedValue.length,
+            ),
+        )
+        is AppScopeInputError.AliasTooLong -> ScopeContractError.InputError.InvalidAlias(
+            alias = domainError.attemptedValue,
+            validationFailure = ScopeContractError.AliasValidationFailure.TooLong(
+                maximumLength = domainError.maximumLength,
+                actualLength = domainError.attemptedValue.length,
+            ),
+        )
+        is AppScopeInputError.AliasInvalidFormat -> ScopeContractError.InputError.InvalidAlias(
+            alias = domainError.attemptedValue,
+            validationFailure = ScopeContractError.AliasValidationFailure.InvalidFormat(
+                expectedPattern = domainError.expectedPattern,
+            ),
+        )
+
+        // Alias business errors
+        is AppScopeInputError.AliasNotFound -> ScopeContractError.BusinessError.AliasNotFound(
+            alias = domainError.alias,
+        )
+        is AppScopeInputError.AliasDuplicate -> ScopeContractError.BusinessError.DuplicateAlias(
+            alias = domainError.alias,
+        )
+        is AppScopeInputError.CannotRemoveCanonicalAlias -> ScopeContractError.BusinessError.CannotRemoveCanonicalAlias
+        is AppScopeInputError.AliasOfDifferentScope -> ScopeContractError.BusinessError.AliasOfDifferentScope(
+            alias = domainError.alias,
+            expectedScopeId = domainError.expectedScopeId,
+            actualScopeId = domainError.actualScopeId,
+        )
+
+        // Other input errors
+        is AppScopeInputError.InvalidAlias -> ScopeContractError.BusinessError.AliasNotFound(
+            alias = domainError.alias,
+        )
+        is AppScopeInputError.InvalidParentId -> ScopeContractError.InputError.InvalidParentId(
+            parentId = domainError.parentId,
+            expectedFormat = "Valid ULID format",
+        )
+
+        // Context errors
+        is ContextError.ContextInUse -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is ContextError.ContextNotFound -> ScopeContractError.BusinessError.NotFound(
+            scopeId = domainError.key,
+        )
+        is ContextError.ContextUpdateConflict -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is ContextError.DuplicateContextKey -> ScopeContractError.BusinessError.DuplicateAlias(
+            alias = domainError.key,
+        )
+        is ContextError.InvalidContextSwitch -> ScopeContractError.BusinessError.NotFound(
+            scopeId = domainError.key,
+        )
+        is ContextError.InvalidFilter -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is ContextError.KeyInvalidFormat -> ScopeContractError.InputError.InvalidId(
+            id = domainError.attemptedKey,
+            expectedFormat = "Valid context key format",
+        )
+        is ContextError.StateNotFound -> ScopeContractError.BusinessError.NotFound(
+            scopeId = domainError.contextId,
+        )
+
+        // ScopeAliasError
+        is ScopeAliasError.AliasDuplicate -> ScopeContractError.BusinessError.DuplicateAlias(
+            alias = domainError.aliasName,
+        )
+        is ScopeAliasError.AliasGenerationFailed -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is ScopeAliasError.AliasGenerationValidationFailed -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is ScopeAliasError.AliasNotFound -> ScopeContractError.BusinessError.AliasNotFound(
+            alias = domainError.aliasName,
+        )
+        is ScopeAliasError.CannotRemoveCanonicalAlias -> ScopeContractError.BusinessError.CannotRemoveCanonicalAlias
+        is ScopeAliasError.DataInconsistencyError.AliasExistsButScopeNotFound -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+
+        // ScopeHierarchyApplicationError
+        is ScopeHierarchyApplicationError.CircularReference -> ScopeContractError.BusinessError.HierarchyViolation(
+            violation = ScopeContractError.HierarchyViolationType.CircularReference(
+                scopeId = domainError.scopeId,
+                parentId = domainError.cyclePath.firstOrNull() ?: "",
+                cyclePath = domainError.cyclePath,
+            ),
+        )
+        is ScopeHierarchyApplicationError.HasChildren -> ScopeContractError.BusinessError.HasChildren(
+            scopeId = domainError.scopeId,
+            childrenCount = domainError.childCount,
+        )
+        is ScopeHierarchyApplicationError.InvalidParentId -> ScopeContractError.InputError.InvalidParentId(
+            parentId = domainError.invalidId,
+            expectedFormat = "Valid ULID format",
+        )
+        is ScopeHierarchyApplicationError.MaxChildrenExceeded -> ScopeContractError.BusinessError.HierarchyViolation(
+            violation = ScopeContractError.HierarchyViolationType.MaxChildrenExceeded(
+                parentId = domainError.parentScopeId,
+                currentChildrenCount = domainError.currentChildrenCount,
+                maximumChildren = domainError.maximumChildren,
+            ),
+        )
+        is ScopeHierarchyApplicationError.MaxDepthExceeded -> ScopeContractError.BusinessError.HierarchyViolation(
+            violation = ScopeContractError.HierarchyViolationType.MaxDepthExceeded(
+                scopeId = domainError.scopeId,
+                attemptedDepth = domainError.attemptedDepth,
+                maximumDepth = domainError.maximumDepth,
+            ),
+        )
+        is ScopeHierarchyApplicationError.ParentNotFound -> ScopeContractError.BusinessError.HierarchyViolation(
+            violation = ScopeContractError.HierarchyViolationType.ParentNotFound(
+                scopeId = domainError.scopeId,
+                parentId = domainError.parentId,
+            ),
+        )
+        is ScopeHierarchyApplicationError.SelfParenting -> ScopeContractError.BusinessError.HierarchyViolation(
+            violation = ScopeContractError.HierarchyViolationType.SelfParenting(
+                scopeId = domainError.scopeId,
+            ),
+        )
+
+        // ScopeUniquenessError
+        is ScopeUniquenessError.DuplicateTitle -> ScopeContractError.BusinessError.DuplicateTitle(
+            title = domainError.title,
+            parentId = domainError.parentScopeId,
+            existingScopeId = domainError.existingScopeId,
+        )
+
+        // CrossAggregateValidationError
+        is CrossAggregateValidationError.CompensationFailure -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is CrossAggregateValidationError.CrossReferenceViolation -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is CrossAggregateValidationError.EventualConsistencyViolation -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is CrossAggregateValidationError.InvariantViolation -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+
+        // PersistenceError
+        is ScopeManagementApplicationError.PersistenceError.ConcurrencyConflict -> ScopeContractError.SystemError.ConcurrentModification(
+            scopeId = domainError.entityId,
+            expectedVersion = domainError.expectedVersion.toLongOrNull() ?: 0,
+            actualVersion = domainError.actualVersion.toLongOrNull() ?: 0,
+        )
+        is ScopeManagementApplicationError.PersistenceError.DataCorruption -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
+        )
+        is ScopeManagementApplicationError.PersistenceError.NotFound -> ScopeContractError.BusinessError.NotFound(
+            scopeId = domainError.entityId ?: "",
+        )
+        is ScopeManagementApplicationError.PersistenceError.StorageUnavailable -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = "scope-management",
         )
     }
 }

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
@@ -210,9 +210,11 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
         is ScopeAliasError.AliasGenerationFailed -> ScopeContractError.SystemError.ServiceUnavailable(
             service = SCOPE_MANAGEMENT_SERVICE,
         )
-        is ScopeAliasError.AliasError -> ScopeContractError.InputError.InvalidTitle(
-            title = domainError.alias,
-            validationFailure = ScopeContractError.TitleValidationFailure.InvalidCharacters(emptyList()),
+        is ScopeAliasError.AliasError -> ScopeContractError.InputError.InvalidAlias(
+            alias = domainError.alias,
+            validationFailure = ScopeContractError.AliasValidationFailure.InvalidFormat(
+                expectedPattern = domainError.reason,
+            ),
         )
         is ScopeAliasError.AliasNotFoundById -> ScopeContractError.BusinessError.AliasNotFound(
             alias = domainError.aliasId.value,

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
@@ -185,13 +185,17 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
             ),
         )
         is ScopeHierarchyError.MaxDepthExceeded -> ScopeContractError.BusinessError.HierarchyViolation(
-            violation = ScopeContractError.HierarchyViolationType.SelfParenting(
+            violation = ScopeContractError.HierarchyViolationType.MaxDepthExceeded(
                 scopeId = domainError.scopeId.value,
+                attemptedDepth = domainError.currentDepth + 1,
+                maximumDepth = domainError.maxDepth,
             ),
         )
         is ScopeHierarchyError.MaxChildrenExceeded -> ScopeContractError.BusinessError.HierarchyViolation(
-            violation = ScopeContractError.HierarchyViolationType.SelfParenting(
-                scopeId = domainError.parentId.value,
+            violation = ScopeContractError.HierarchyViolationType.MaxChildrenExceeded(
+                parentId = domainError.parentId.value,
+                currentChildrenCount = domainError.currentCount,
+                maximumChildren = domainError.maxChildren,
             ),
         )
         is ScopeHierarchyError.HierarchyUnavailable -> ScopeContractError.SystemError.ServiceUnavailable(

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
@@ -31,6 +31,13 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
         ScopeInputError.IdError.InvalidIdFormat.IdFormatType.CUSTOM_FORMAT -> "custom format"
     }
 
+    private fun presentAliasPattern(patternType: ScopeInputError.AliasError.InvalidAliasFormat.AliasPatternType): String = when (patternType) {
+        ScopeInputError.AliasError.InvalidAliasFormat.AliasPatternType.LOWERCASE_WITH_HYPHENS -> "lowercase with hyphens (e.g., my-alias)"
+        ScopeInputError.AliasError.InvalidAliasFormat.AliasPatternType.ALPHANUMERIC -> "alphanumeric characters only"
+        ScopeInputError.AliasError.InvalidAliasFormat.AliasPatternType.ULID_LIKE -> "ULID-like format"
+        ScopeInputError.AliasError.InvalidAliasFormat.AliasPatternType.CUSTOM_PATTERN -> "custom pattern"
+    }
+
     override fun mapToContractError(domainError: ScopesError): ScopeContractError = when (domainError) {
         // Input validation errors
         is ScopeInputError.IdError -> mapIdError(domainError)
@@ -53,8 +60,8 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
         is ScopesError.Conflict -> mapConflictError(domainError)
         is ScopesError.ConcurrencyError -> ScopeContractError.SystemError.ConcurrentModification(
             scopeId = domainError.aggregateId,
-            expectedVersion = domainError.expectedVersion?.toLong() ?: 0,
-            actualVersion = domainError.actualVersion?.toLong() ?: 0,
+            expectedVersion = domainError.expectedVersion?.toLong() ?: -1L,
+            actualVersion = domainError.actualVersion?.toLong() ?: -1L,
         )
         is ScopesError.RepositoryError -> ScopeContractError.SystemError.ServiceUnavailable(
             service = SCOPE_MANAGEMENT_SERVICE,
@@ -115,29 +122,29 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
         )
     }
 
-    private fun mapAliasError(domainError: ScopeInputError.AliasError): ScopeContractError.InputError.InvalidTitle = when (domainError) {
-        is ScopeInputError.AliasError.EmptyAlias -> ScopeContractError.InputError.InvalidTitle(
-            title = "",
-            validationFailure = ScopeContractError.TitleValidationFailure.Empty,
+    private fun mapAliasError(domainError: ScopeInputError.AliasError): ScopeContractError.InputError.InvalidAlias = when (domainError) {
+        is ScopeInputError.AliasError.EmptyAlias -> ScopeContractError.InputError.InvalidAlias(
+            alias = "",
+            validationFailure = ScopeContractError.AliasValidationFailure.Empty,
         )
-        is ScopeInputError.AliasError.AliasTooShort -> ScopeContractError.InputError.InvalidTitle(
-            title = "",
-            validationFailure = ScopeContractError.TitleValidationFailure.TooShort(
+        is ScopeInputError.AliasError.AliasTooShort -> ScopeContractError.InputError.InvalidAlias(
+            alias = "",
+            validationFailure = ScopeContractError.AliasValidationFailure.TooShort(
                 minimumLength = domainError.minLength,
                 actualLength = 0,
             ),
         )
-        is ScopeInputError.AliasError.AliasTooLong -> ScopeContractError.InputError.InvalidTitle(
-            title = "",
-            validationFailure = ScopeContractError.TitleValidationFailure.TooLong(
+        is ScopeInputError.AliasError.AliasTooLong -> ScopeContractError.InputError.InvalidAlias(
+            alias = "",
+            validationFailure = ScopeContractError.AliasValidationFailure.TooLong(
                 maximumLength = domainError.maxLength,
                 actualLength = 0,
             ),
         )
-        is ScopeInputError.AliasError.InvalidAliasFormat -> ScopeContractError.InputError.InvalidTitle(
-            title = domainError.alias,
-            validationFailure = ScopeContractError.TitleValidationFailure.InvalidCharacters(
-                prohibitedCharacters = emptyList(),
+        is ScopeInputError.AliasError.InvalidAliasFormat -> ScopeContractError.InputError.InvalidAlias(
+            alias = domainError.alias,
+            validationFailure = ScopeContractError.AliasValidationFailure.InvalidFormat(
+                expectedPattern = presentAliasPattern(domainError.expectedPattern),
             ),
         )
     }
@@ -200,9 +207,7 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
             alias = domainError.alias,
         )
         is ScopeAliasError.CannotRemoveCanonicalAlias -> ScopeContractError.BusinessError.CannotRemoveCanonicalAlias
-        is ScopeAliasError.AliasGenerationFailed,
-        is ScopeAliasError.DataInconsistencyError,
-        -> ScopeContractError.SystemError.ServiceUnavailable(
+        is ScopeAliasError.AliasGenerationFailed -> ScopeContractError.SystemError.ServiceUnavailable(
             service = SCOPE_MANAGEMENT_SERVICE,
         )
         is ScopeAliasError.AliasError -> ScopeContractError.InputError.InvalidTitle(
@@ -214,6 +219,9 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
         )
         is ScopeAliasError.DataInconsistencyError.AliasReferencesNonExistentScope -> ScopeContractError.BusinessError.NotFound(
             scopeId = domainError.scopeId.toString(),
+        )
+        is ScopeAliasError.DataInconsistencyError -> ScopeContractError.SystemError.ServiceUnavailable(
+            service = SCOPE_MANAGEMENT_SERVICE,
         )
     }
 

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapper.kt
@@ -200,7 +200,9 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
             alias = domainError.alias,
         )
         is ScopeAliasError.CannotRemoveCanonicalAlias -> ScopeContractError.BusinessError.CannotRemoveCanonicalAlias
-        is ScopeAliasError.AliasGenerationFailed -> ScopeContractError.SystemError.ServiceUnavailable(
+        is ScopeAliasError.AliasGenerationFailed,
+        is ScopeAliasError.DataInconsistencyError,
+        -> ScopeContractError.SystemError.ServiceUnavailable(
             service = SCOPE_MANAGEMENT_SERVICE,
         )
         is ScopeAliasError.AliasError -> ScopeContractError.InputError.InvalidTitle(
@@ -212,9 +214,6 @@ class ErrorMapper(logger: Logger) : BaseErrorMapper<ScopesError, ScopeContractEr
         )
         is ScopeAliasError.DataInconsistencyError.AliasReferencesNonExistentScope -> ScopeContractError.BusinessError.NotFound(
             scopeId = domainError.scopeId.toString(),
-        )
-        is ScopeAliasError.DataInconsistencyError -> ScopeContractError.SystemError.ServiceUnavailable(
-            service = SCOPE_MANAGEMENT_SERVICE,
         )
     }
 

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementQueryPortAdapter.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ScopeManagementQueryPortAdapter.kt
@@ -27,7 +27,6 @@ import io.github.kamiazya.scopes.scopemanagement.application.query.handler.scope
 import io.github.kamiazya.scopes.scopemanagement.application.query.handler.scope.GetScopeByAliasHandler
 import io.github.kamiazya.scopes.scopemanagement.application.query.handler.scope.GetScopeByIdHandler
 import io.github.kamiazya.scopes.scopemanagement.application.query.handler.scope.ListAliasesHandler
-import io.github.kamiazya.scopes.scopemanagement.infrastructure.adapters.ApplicationErrorMapper
 import io.github.kamiazya.scopes.scopemanagement.application.query.dto.GetScopeByAlias as AppGetScopeByAliasQuery
 
 /**

--- a/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/ActiveContextRepositoryImpl.kt
+++ b/contexts/scope-management/infrastructure/src/main/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/repository/ActiveContextRepositoryImpl.kt
@@ -2,7 +2,6 @@ package io.github.kamiazya.scopes.scopemanagement.infrastructure.repository
 
 import arrow.core.Either
 import arrow.core.raise.either
-import io.github.kamiazya.scopes.scopemanagement.db.Context_views
 import io.github.kamiazya.scopes.scopemanagement.db.GetActiveContext
 import io.github.kamiazya.scopes.scopemanagement.db.ScopeManagementDatabase
 import io.github.kamiazya.scopes.scopemanagement.domain.entity.ContextView
@@ -148,41 +147,6 @@ class ActiveContextRepositoryImpl(private val database: ScopeManagementDatabase)
                 )
             }
         }
-    }
-
-    private fun rowToContextView(row: Context_views): ContextView {
-        val id = ContextViewId.create(row.id).fold(
-            ifLeft = { error("Invalid id in database: $it") },
-            ifRight = { it },
-        )
-        val key = ContextViewKey.create(row.key).fold(
-            ifLeft = { error("Invalid key in database: $it") },
-            ifRight = { it },
-        )
-        val name = ContextViewName.create(row.name).fold(
-            ifLeft = { error("Invalid name in database: $it") },
-            ifRight = { it },
-        )
-        val description = row.description?.let { desc ->
-            ContextViewDescription.create(desc).fold(
-                ifLeft = { error("Invalid description in database: $it") },
-                ifRight = { it },
-            )
-        }
-        val filter = ContextViewFilter.create(row.filter).fold(
-            ifLeft = { error("Invalid filter in database: $it") },
-            ifRight = { it },
-        )
-
-        return ContextView(
-            id = id,
-            key = key,
-            name = name,
-            description = description,
-            filter = filter,
-            createdAt = Instant.fromEpochMilliseconds(row.created_at),
-            updatedAt = Instant.fromEpochMilliseconds(row.updated_at),
-        )
     }
 
     private fun activeContextToContextView(row: GetActiveContext): ContextView? {

--- a/contexts/scope-management/infrastructure/src/test/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapperTest.kt
+++ b/contexts/scope-management/infrastructure/src/test/kotlin/io/github/kamiazya/scopes/scopemanagement/infrastructure/adapters/ErrorMapperTest.kt
@@ -88,46 +88,46 @@ class ErrorMapperTest :
                     failure.maximumLength shouldBe 500
                 }
 
-                it("should map ScopeInputError.AliasError.EmptyAlias to InvalidTitle") {
+                it("should map ScopeInputError.AliasError.EmptyAlias to InvalidAlias") {
                     val domainError = ScopeInputError.AliasError.EmptyAlias
                     val contractError = errorMapper.mapToContractError(domainError)
 
-                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidTitle>()
-                    result.title shouldBe ""
-                    result.validationFailure.shouldBeInstanceOf<ScopeContractError.TitleValidationFailure.Empty>()
+                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidAlias>()
+                    result.alias shouldBe ""
+                    result.validationFailure.shouldBeInstanceOf<ScopeContractError.AliasValidationFailure.Empty>()
                 }
 
-                it("should map ScopeInputError.AliasError.AliasTooShort to InvalidTitle") {
+                it("should map ScopeInputError.AliasError.AliasTooShort to InvalidAlias") {
                     val domainError = ScopeInputError.AliasError.AliasTooShort(minLength = 3)
                     val contractError = errorMapper.mapToContractError(domainError)
 
-                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidTitle>()
-                    result.title shouldBe ""
-                    val failure = result.validationFailure.shouldBeInstanceOf<ScopeContractError.TitleValidationFailure.TooShort>()
+                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidAlias>()
+                    result.alias shouldBe ""
+                    val failure = result.validationFailure.shouldBeInstanceOf<ScopeContractError.AliasValidationFailure.TooShort>()
                     failure.minimumLength shouldBe 3
                 }
 
-                it("should map ScopeInputError.AliasError.AliasTooLong to InvalidTitle") {
+                it("should map ScopeInputError.AliasError.AliasTooLong to InvalidAlias") {
                     val domainError = ScopeInputError.AliasError.AliasTooLong(maxLength = 50)
                     val contractError = errorMapper.mapToContractError(domainError)
 
-                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidTitle>()
-                    result.title shouldBe ""
-                    val failure = result.validationFailure.shouldBeInstanceOf<ScopeContractError.TitleValidationFailure.TooLong>()
+                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidAlias>()
+                    result.alias shouldBe ""
+                    val failure = result.validationFailure.shouldBeInstanceOf<ScopeContractError.AliasValidationFailure.TooLong>()
                     failure.maximumLength shouldBe 50
                 }
 
-                it("should map ScopeInputError.AliasError.InvalidAliasFormat to InvalidTitle") {
+                it("should map ScopeInputError.AliasError.InvalidAliasFormat to InvalidAlias") {
                     val domainError = ScopeInputError.AliasError.InvalidAliasFormat(
                         alias = "invalid@alias",
                         expectedPattern = ScopeInputError.AliasError.InvalidAliasFormat.AliasPatternType.LOWERCASE_WITH_HYPHENS,
                     )
                     val contractError = errorMapper.mapToContractError(domainError)
 
-                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidTitle>()
-                    result.title shouldBe "invalid@alias"
-                    val failure = result.validationFailure.shouldBeInstanceOf<ScopeContractError.TitleValidationFailure.InvalidCharacters>()
-                    failure.prohibitedCharacters shouldBe emptyList<Char>()
+                    val result = contractError.shouldBeInstanceOf<ScopeContractError.InputError.InvalidAlias>()
+                    result.alias shouldBe "invalid@alias"
+                    val failure = result.validationFailure.shouldBeInstanceOf<ScopeContractError.AliasValidationFailure.InvalidFormat>()
+                    failure.expectedPattern shouldBe "lowercase with hyphens (e.g., my-alias)"
                 }
             }
 

--- a/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/errors/ScopeContractError.kt
+++ b/contracts/scope-management/src/main/kotlin/io/github/kamiazya/scopes/contracts/scopemanagement/errors/ScopeContractError.kt
@@ -33,6 +33,16 @@ public sealed interface ScopeContractError {
     }
 
     /**
+     * Specific validation failures for alias.
+     */
+    public sealed interface AliasValidationFailure {
+        public data object Empty : AliasValidationFailure
+        public data class TooShort(public val minimumLength: Int, public val actualLength: Int) : AliasValidationFailure
+        public data class TooLong(public val maximumLength: Int, public val actualLength: Int) : AliasValidationFailure
+        public data class InvalidFormat(public val expectedPattern: String) : AliasValidationFailure
+    }
+
+    /**
      * Specific types of hierarchy violations.
      */
     public sealed interface HierarchyViolationType {
@@ -107,6 +117,13 @@ public sealed interface ScopeContractError {
          * @property expectedFormat Optional description of expected format
          */
         public data class InvalidParentId(public val parentId: String, public val expectedFormat: String? = null) : InputError
+
+        /**
+         * Invalid scope alias.
+         * @property alias The invalid alias value
+         * @property validationFailure Specific reason for validation failure
+         */
+        public data class InvalidAlias(public val alias: String, public val validationFailure: AliasValidationFailure) : InputError
     }
 
     /**
@@ -175,6 +192,14 @@ public sealed interface ScopeContractError {
          * The canonical alias is the primary identifier and cannot be removed.
          */
         public data object CannotRemoveCanonicalAlias : BusinessError
+
+        /**
+         * Alias belongs to a different scope.
+         * @property alias The alias
+         * @property expectedScopeId The expected scope ID
+         * @property actualScopeId The actual scope ID that owns the alias
+         */
+        public data class AliasOfDifferentScope(public val alias: String, public val expectedScopeId: String, public val actualScopeId: String) : BusinessError
     }
 
     /**

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/aspect/DefineCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/commands/aspect/DefineCommand.kt
@@ -123,12 +123,4 @@ class DefineCommand :
             )
         }
     }
-
-    private fun formatType(type: AspectType): String = when (type) {
-        is AspectType.Text -> "Text"
-        is AspectType.Numeric -> "Numeric"
-        is AspectType.BooleanType -> "Boolean"
-        is AspectType.Ordered -> "Ordered (${type.allowedValues.joinToString(", ") { it.value }})"
-        is AspectType.Duration -> "Duration (ISO 8601)"
-    }
 }

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/core/ScopesCliktCommand.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/core/ScopesCliktCommand.kt
@@ -72,10 +72,12 @@ abstract class ScopesCliktCommand(
         is ScopeContractError.BusinessError.HasChildren -> ExitCode.STATE_ERROR
         is ScopeContractError.BusinessError.AliasNotFound -> ExitCode.ALIAS_NOT_FOUND
         is ScopeContractError.BusinessError.CannotRemoveCanonicalAlias -> ExitCode.VALIDATION_ERROR
+        is ScopeContractError.BusinessError.AliasOfDifferentScope -> ExitCode.VALIDATION_ERROR
         is ScopeContractError.InputError.InvalidTitle -> ExitCode.VALIDATION_ERROR
         is ScopeContractError.InputError.InvalidDescription -> ExitCode.VALIDATION_ERROR
         is ScopeContractError.InputError.InvalidId -> ExitCode.VALIDATION_ERROR
         is ScopeContractError.InputError.InvalidParentId -> ExitCode.VALIDATION_ERROR
+        is ScopeContractError.InputError.InvalidAlias -> ExitCode.VALIDATION_ERROR
         is ScopeContractError.SystemError.ServiceUnavailable -> ExitCode.UNAVAILABLE
         is ScopeContractError.SystemError.Timeout -> ExitCode.TEMP_FAIL
         is ScopeContractError.SystemError.ConcurrentModification -> ExitCode.STATE_ERROR

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/mappers/ContractErrorMessageMapper.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/mappers/ContractErrorMessageMapper.kt
@@ -36,6 +36,15 @@ object ContractErrorMessageMapper {
             val formatHint = error.expectedFormat?.let { " (expected: $it)" } ?: ""
             "Invalid parent scope ID: ${error.parentId}$formatHint"
         }
+        is ScopeContractError.InputError.InvalidAlias -> when (val failure = error.validationFailure) {
+            is ScopeContractError.AliasValidationFailure.Empty -> "Alias cannot be empty"
+            is ScopeContractError.AliasValidationFailure.TooShort ->
+                "Alias is too short (minimum ${failure.minimumLength} characters, got ${failure.actualLength})"
+            is ScopeContractError.AliasValidationFailure.TooLong ->
+                "Alias is too long (maximum ${failure.maximumLength} characters, got ${failure.actualLength})"
+            is ScopeContractError.AliasValidationFailure.InvalidFormat ->
+                "Invalid alias format (expected: ${failure.expectedPattern})"
+        }
 
         is ScopeContractError.BusinessError.NotFound -> {
             if (debug) {
@@ -79,6 +88,8 @@ object ContractErrorMessageMapper {
         is ScopeContractError.BusinessError.DuplicateAlias -> "Alias already exists: ${error.alias}"
         is ScopeContractError.BusinessError.CannotRemoveCanonicalAlias ->
             "Cannot remove canonical alias. Set a different alias as canonical first."
+        is ScopeContractError.BusinessError.AliasOfDifferentScope ->
+            "Alias '${error.alias}' belongs to a different scope (expected: ${error.expectedScopeId}, actual: ${error.actualScopeId})"
 
         is ScopeContractError.SystemError.ServiceUnavailable -> "Service unavailable: ${error.service}"
         is ScopeContractError.SystemError.Timeout -> "Operation timed out: ${error.operation}"

--- a/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/mappers/ErrorMessageMapper.kt
+++ b/interfaces/cli/src/main/kotlin/io/github/kamiazya/scopes/interfaces/cli/mappers/ErrorMessageMapper.kt
@@ -43,6 +43,15 @@ object ErrorMessageMapper {
             }
             is ScopeContractError.InputError.InvalidParentId ->
                 "Invalid parent ID: ${error.parentId}${error.expectedFormat?.let { " (expected: $it)" } ?: ""}"
+            is ScopeContractError.InputError.InvalidAlias -> when (val failure = error.validationFailure) {
+                is ScopeContractError.AliasValidationFailure.Empty -> "Alias cannot be empty"
+                is ScopeContractError.AliasValidationFailure.TooShort ->
+                    "Alias too short: minimum ${failure.minimumLength} characters"
+                is ScopeContractError.AliasValidationFailure.TooLong ->
+                    "Alias too long: maximum ${failure.maximumLength} characters"
+                is ScopeContractError.AliasValidationFailure.InvalidFormat ->
+                    "Invalid alias format (expected: ${failure.expectedPattern})"
+            }
         }
         is ScopeContractError.BusinessError -> when (error) {
             is ScopeContractError.BusinessError.NotFound -> "Not found: ${error.scopeId}"
@@ -69,6 +78,8 @@ object ErrorMessageMapper {
             is ScopeContractError.BusinessError.DuplicateAlias -> "Alias already exists: ${error.alias}"
             is ScopeContractError.BusinessError.CannotRemoveCanonicalAlias ->
                 "Cannot remove canonical alias"
+            is ScopeContractError.BusinessError.AliasOfDifferentScope ->
+                "Alias '${error.alias}' belongs to different scope"
         }
         is ScopeContractError.SystemError -> when (error) {
             is ScopeContractError.SystemError.ServiceUnavailable ->

--- a/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/DefaultErrorMapper.kt
+++ b/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/DefaultErrorMapper.kt
@@ -57,13 +57,15 @@ internal class DefaultErrorMapper : ErrorMapper {
         is ScopeContractError.BusinessError.DuplicateTitle,
         -> -32012 // Duplicate
         is ScopeContractError.BusinessError.HierarchyViolation -> -32013 // Hierarchy violation
-        is ScopeContractError.BusinessError.CannotRemoveCanonicalAlias -> -32013 // Hierarchy violation (alias constraint)
+        is ScopeContractError.BusinessError.CannotRemoveCanonicalAlias,
+        is ScopeContractError.BusinessError.AliasOfDifferentScope,
+        -> -32013 // Hierarchy violation (alias constraint)
         is ScopeContractError.BusinessError.AlreadyDeleted,
         is ScopeContractError.BusinessError.ArchivedScope,
+        is ScopeContractError.BusinessError.NotArchived,
         -> -32014 // State conflict
         is ScopeContractError.BusinessError.HasChildren -> -32010 // Business constraint violation
         is ScopeContractError.SystemError -> -32000 // Server error
-        else -> -32010 // Generic business error
     }
 
     private fun mapContractErrorMessage(error: ScopeContractError): String = when (error) {
@@ -71,7 +73,9 @@ internal class DefaultErrorMapper : ErrorMapper {
         is ScopeContractError.BusinessError.AliasNotFound -> "Alias not found: ${error.alias}"
         is ScopeContractError.BusinessError.DuplicateAlias -> "Duplicate alias: ${error.alias}"
         is ScopeContractError.BusinessError.DuplicateTitle -> "Duplicate title"
+        is ScopeContractError.BusinessError.AliasOfDifferentScope -> "Alias belongs to different scope: ${error.alias}"
         is ScopeContractError.InputError.InvalidId -> "Invalid id: ${error.id}"
+        is ScopeContractError.InputError.InvalidAlias -> "Invalid alias: ${error.alias}"
         is ScopeContractError.SystemError.ServiceUnavailable -> "Service unavailable: ${error.service}"
         is ScopeContractError.SystemError.Timeout -> "Timeout: ${error.operation}"
         is ScopeContractError.SystemError.ConcurrentModification -> "Concurrent modification"

--- a/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/IdempotencyService.kt
+++ b/interfaces/mcp/src/main/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/IdempotencyService.kt
@@ -24,6 +24,7 @@ interface IdempotencyService {
          */
         val IDEMPOTENCY_KEY_PATTERN = Regex(IDEMPOTENCY_KEY_PATTERN_STRING)
     }
+
     /**
      * Check if a tool call with the given arguments has been seen before.
      *

--- a/interfaces/mcp/src/test/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/IdempotencyKeyPatternTest.kt
+++ b/interfaces/mcp/src/test/kotlin/io/github/kamiazya/scopes/interfaces/mcp/support/IdempotencyKeyPatternTest.kt
@@ -3,81 +3,82 @@ package io.github.kamiazya.scopes.interfaces.mcp.support
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
-class IdempotencyKeyPatternTest : DescribeSpec({
-    describe("IdempotencyService.IDEMPOTENCY_KEY_PATTERN") {
-        val pattern = IdempotencyService.IDEMPOTENCY_KEY_PATTERN
+class IdempotencyKeyPatternTest :
+    DescribeSpec({
+        describe("IdempotencyService.IDEMPOTENCY_KEY_PATTERN") {
+            val pattern = IdempotencyService.IDEMPOTENCY_KEY_PATTERN
 
-        it("should accept valid idempotency keys") {
-            val validKeys = listOf(
-                "12345678",                      // Minimum 8 characters
-                "a-b_c-d_",                      // Mix of allowed characters
-                "ABCDEFGH",                      // Uppercase
-                "abcdefgh",                      // Lowercase
-                "123_ABC-",                      // Mix of all types
-                "a".repeat(128),                 // Maximum 128 characters
-                "test-key-123",                  // Typical format
-                "request_12345678",              // Underscore format
-                "2024-01-01_request_123"         // Date-like format
-            )
+            it("should accept valid idempotency keys") {
+                val validKeys = listOf(
+                    "12345678", // Minimum 8 characters
+                    "a-b_c-d_", // Mix of allowed characters
+                    "ABCDEFGH", // Uppercase
+                    "abcdefgh", // Lowercase
+                    "123_ABC-", // Mix of all types
+                    "a".repeat(128), // Maximum 128 characters
+                    "test-key-123", // Typical format
+                    "request_12345678", // Underscore format
+                    "2024-01-01_request_123", // Date-like format
+                )
 
-            validKeys.forEach { key ->
-                pattern.matches(key) shouldBe true
+                validKeys.forEach { key ->
+                    pattern.matches(key) shouldBe true
+                }
+            }
+
+            it("should reject invalid idempotency keys") {
+                val invalidKeys = listOf(
+                    "", // Empty
+                    "1234567", // Too short (7 chars)
+                    "a".repeat(129), // Too long (129 chars)
+                    "test key", // Contains space
+                    "test@key", // Contains @
+                    "test#key", // Contains #
+                    "test.key", // Contains .
+                    "test/key", // Contains /
+                    "test\\key", // Contains \
+                    "test:key", // Contains :
+                    "test;key", // Contains ;
+                    "test,key", // Contains ,
+                    "test<key", // Contains <
+                    "test>key", // Contains >
+                    "test?key", // Contains ?
+                    "test[key", // Contains [
+                    "test]key", // Contains ]
+                    "test{key", // Contains {
+                    "test}key", // Contains }
+                    "test|key", // Contains |
+                    "test~key", // Contains ~
+                    "test!key", // Contains !
+                    "test\"key", // Contains "
+                    "test'key", // Contains '
+                    "test`key", // Contains `
+                    "test\$key", // Contains $
+                    "test%key", // Contains %
+                    "test^key", // Contains ^
+                    "test&key", // Contains &
+                    "test*key", // Contains *
+                    "test(key", // Contains (
+                    "test)key", // Contains )
+                    "test+key", // Contains +
+                    "test=key", // Contains =
+                    "テストキー", // Non-ASCII characters
+                    "test\nkey", // Contains newline
+                    "test\tkey", // Contains tab
+                    "test\rkey", // Contains carriage return
+                )
+
+                invalidKeys.forEach { key ->
+                    pattern.matches(key) shouldBe false
+                }
+            }
+
+            it("regex and string constants should be in sync") {
+                // Ensure the Regex pattern matches the string constant
+                pattern.pattern shouldBe IdempotencyService.IDEMPOTENCY_KEY_PATTERN_STRING
+
+                // Also verify the expected pattern value
+                IdempotencyService.IDEMPOTENCY_KEY_PATTERN_STRING shouldBe "^[A-Za-z0-9_-]{8,128}$"
             }
         }
-
-        it("should reject invalid idempotency keys") {
-            val invalidKeys = listOf(
-                "",                              // Empty
-                "1234567",                       // Too short (7 chars)
-                "a".repeat(129),                 // Too long (129 chars)
-                "test key",                      // Contains space
-                "test@key",                      // Contains @
-                "test#key",                      // Contains #
-                "test.key",                      // Contains .
-                "test/key",                      // Contains /
-                "test\\key",                     // Contains \
-                "test:key",                      // Contains :
-                "test;key",                      // Contains ;
-                "test,key",                      // Contains ,
-                "test<key",                      // Contains <
-                "test>key",                      // Contains >
-                "test?key",                      // Contains ?
-                "test[key",                      // Contains [
-                "test]key",                      // Contains ]
-                "test{key",                      // Contains {
-                "test}key",                      // Contains }
-                "test|key",                      // Contains |
-                "test~key",                      // Contains ~
-                "test!key",                      // Contains !
-                "test\"key",                     // Contains "
-                "test'key",                      // Contains '
-                "test`key",                      // Contains `
-                "test\$key",                     // Contains $
-                "test%key",                      // Contains %
-                "test^key",                      // Contains ^
-                "test&key",                      // Contains &
-                "test*key",                      // Contains *
-                "test(key",                      // Contains (
-                "test)key",                      // Contains )
-                "test+key",                      // Contains +
-                "test=key",                      // Contains =
-                "テストキー",                      // Non-ASCII characters
-                "test\nkey",                     // Contains newline
-                "test\tkey",                     // Contains tab
-                "test\rkey"                      // Contains carriage return
-            )
-
-            invalidKeys.forEach { key ->
-                pattern.matches(key) shouldBe false
-            }
-        }
-
-        it("regex and string constants should be in sync") {
-            // Ensure the Regex pattern matches the string constant
-            pattern.pattern shouldBe IdempotencyService.IDEMPOTENCY_KEY_PATTERN_STRING
-            
-            // Also verify the expected pattern value
-            IdempotencyService.IDEMPOTENCY_KEY_PATTERN_STRING shouldBe "^[A-Za-z0-9_-]{8,128}$"
-        }
-    }
-})
+    })


### PR DESCRIPTION
## Summary
This PR addresses SonarQube quality gate failures and refactors error handling architecture to improve code maintainability and type safety.

### Key Changes:
- Reduced code duplication from 7.71% to below 3% threshold
- Removed redundant `else` branches in error mappers to leverage Kotlin's sealed class exhaustiveness checking
- Separated error message generation from Application layer to Infrastructure layer
- Added structured error information with `attemptedValue` for better debugging

### Technical Improvements:
1. **Error Architecture Refactoring**
   - Moved error message generation from Application layer to Infrastructure layer (Clean Architecture)
   - Added structured error types to Contract layer (`AliasValidationFailure`, etc.)
   - Updated all handlers to pass actual attempted values for validation errors

2. **Type Safety Improvements**
   - Removed redundant `else` branches where sealed classes allow exhaustive checking
   - Compiler now enforces handling of all error cases
   - Future error type additions will cause compile-time errors, preventing bugs

3. **SonarQube Fixes**
   - Fixed code duplication issues
   - Resolved cognitive complexity warnings
   - Removed unnecessary casts and non-null assertions

## Test Plan
- [x] All existing tests pass
- [x] Build succeeds without warnings
- [x] SonarQube quality gate passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public contract now reports detailed alias validation (InvalidAlias + specific reasons) and AliasOfDifferentScope; CLI and MCP show clearer messages and map them to validation exit codes.

- Refactor
  - Centralized and strengthened alias/scope validation and error mapping; improved null-safety and more precise persistence/concurrency error translations.

- Tests/Chores
  - Minor formatting and test updates; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->