### PR TITLE
fix: Centralize version management in gradle/libs.versions.toml

### DIFF
--- a/apps/scopes/build.gradle.kts
+++ b/apps/scopes/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.detekt)
     alias(libs.plugins.graalvm.native)
-    id("org.cyclonedx.bom") version "2.4.0"
-    id("org.spdx.sbom") version "0.9.0"
+    alias(libs.plugins.cyclonedx.bom)
+    alias(libs.plugins.spdx.sbom)
     application
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.ktlint)
     alias(libs.plugins.spotless)
-    id("org.cyclonedx.bom") version "2.4.0"
-    id("org.spdx.sbom") version "0.9.0"
+    alias(libs.plugins.cyclonedx.bom)
+    alias(libs.plugins.spdx.sbom)
 }
 
 group = "io.github.kamiazya"
@@ -25,7 +25,11 @@ allprojects {
     // Force Netty HTTP/2 to patched version to fix security vulnerability GHSA-prj3-ccx8-p6x4
     configurations.configureEach {
         resolutionStrategy {
-            force("io.netty:netty-codec-http2:4.2.6.Final")
+            force(
+                libs.netty.codec.http2
+                    .get()
+                    .toString(),
+            )
         }
     }
 }
@@ -53,7 +57,11 @@ subprojects {
         resolutionStrategy {
             preferProjectModules()
             // Force Netty to patched version to fix GHSA-prj3-ccx8-p6x4 vulnerability
-            force("io.netty:netty-codec-http2:4.2.6.Final")
+            force(
+                libs.netty.codec.http2
+                    .get()
+                    .toString(),
+            )
         }
     }
 }
@@ -108,7 +116,10 @@ tasks.register("checkGraalVM") {
 }
 
 ktlint {
-    version.set("1.5.0")
+    version.set(
+        libs.versions.ktlint.tool
+            .get(),
+    )
     outputToConsole.set(true)
     coloredOutput.set(true)
     verbose.set(true)
@@ -141,24 +152,29 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
     kotlin {
         target("**/*.kt")
         targetExclude("**/build/**/*.kt", "**/.tmp/**/*.kt")
-        ktlint("1.5.0")
-            .editorConfigOverride(
-                mapOf(
-                    "indent_size" to 4,
-                    "continuation_indent_size" to 4,
-                    "max_line_length" to 160,
-                    "insert_final_newline" to true,
-                    "ktlint_standard_no-wildcard-imports" to "disabled",
-                    "ktlint_standard_package-name" to "disabled",
-                    "ktlint_standard_value-parameter-comment" to "disabled",
-                ),
-            )
+        ktlint(
+            libs.versions.ktlint.tool
+                .get(),
+        ).editorConfigOverride(
+            mapOf(
+                "indent_size" to 4,
+                "continuation_indent_size" to 4,
+                "max_line_length" to 160,
+                "insert_final_newline" to true,
+                "ktlint_standard_no-wildcard-imports" to "disabled",
+                "ktlint_standard_package-name" to "disabled",
+                "ktlint_standard_value-parameter-comment" to "disabled",
+            ),
+        )
         trimTrailingWhitespace()
         endWithNewline()
     }
     kotlinGradle {
         target("**/*.gradle.kts")
-        ktlint("1.5.0")
+        ktlint(
+            libs.versions.ktlint.tool
+                .get(),
+        )
         trimTrailingWhitespace()
         endWithNewline()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,14 @@ ktor = "2.3.12"
 okio = "3.16.0"
 kotlinx-io = "0.8.0"
 
+# Build plugins
+cyclonedx-bom = "2.4.0"
+spdx-sbom = "0.9.0"
+ktlint-tool = "1.5.0"
+
+# Security patches
+netty-codec-http2 = "4.2.6.Final"
+
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
@@ -70,6 +78,9 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-io-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-io-core-jvm", version.ref = "kotlinx-io" }
 
+# Security patches
+netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty-codec-http2" }
+
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -79,6 +90,8 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 gradle-develocity = { id = "com.gradle.develocity", version.ref = "gradle-develocity" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx-bom" }
+spdx-sbom = { id = "org.spdx.sbom", version.ref = "spdx-sbom" }
 
 [bundles]
 kotest = ["kotest-runner-junit5", "kotest-assertions-core", "kotest-assertions-arrow", "kotest-property"]


### PR DESCRIPTION
## Summary

This PR centralizes version management by moving all hardcoded Gradle plugin and dependency versions to `gradle/libs.versions.toml`, ensuring consistent version management across the project.

## Changes Made

### Added to `gradle/libs.versions.toml`:
- `cyclonedx-bom = "2.4.0"`
- `spdx-sbom = "0.9.0"`  
- `ktlint-tool = "1.5.0"`
- `netty-codec-http2 = "4.2.6.Final"` (security patch)

### Updated version references:
- **`build.gradle.kts`**: 
  - Replaced `id("org.cyclonedx.bom") version "2.4.0"` with `alias(libs.plugins.cyclonedx.bom)`
  - Replaced `id("org.spdx.sbom") version "0.9.0"` with `alias(libs.plugins.spdx.sbom)`
  - Replaced `version.set("1.5.0")` with `version.set(libs.versions.ktlint.tool.get())`
  - Replaced `ktlint("1.5.0")` with `ktlint(libs.versions.ktlint.tool.get())`
  - Replaced `force("io.netty:netty-codec-http2:4.2.6.Final")` with `force(libs.netty.codec.http2.get().toString())`

- **`apps/scopes/build.gradle.kts`**:
  - Replaced `id("org.cyclonedx.bom") version "2.4.0"` with `alias(libs.plugins.cyclonedx.bom)`
  - Replaced `id("org.spdx.sbom") version "0.9.0"` with `alias(libs.plugins.spdx.sbom)`

### Note
`settings.gradle.kts` retains direct version specification for the gradle-develocity plugin as version catalog usage in settings.gradle.kts has limitations in the current Gradle version.

## Benefits

- ✅ **Centralized Management**: All versions in one place (`gradle/libs.versions.toml`)
- ✅ **Consistency**: No duplicate version specifications
- ✅ **Maintainability**: Version updates only require changes in one file
- ✅ **Build Verification**: All builds pass with new version management

## Test Plan

- [x] Build verification: `./gradlew :platform-commons:build` ✅
- [x] Lint verification: `./gradlew ktlintCheck` ✅
- [x] Full build verification: `./gradlew :apps-scopes:build` ✅
- [x] Formatting verification: `./gradlew spotlessApply` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)