### PR TITLE
fix: Add attestations:write permission to version-and-release workflow

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -12,6 +12,7 @@ permissions:
   pull-requests: write
   id-token: write
   actions: read
+  attestations: write
 
 jobs:
   version-and-release:


### PR DESCRIPTION
## Summary

Fixes a workflow validation error where the `version-and-release.yml` workflow was calling `release.yml` but missing the required `attestations: write` permission.

## Problem

The workflow was failing validation with this error:
```
The workflow is requesting 'attestations: write', but is only allowed 'attestations: none'
```

This occurred because:
- The `release.yml` workflow requires `attestations: write` permission (line 27)
- The `version-and-release.yml` workflow was only providing limited permissions
- When using `workflow_call`, the calling workflow must have all permissions that the called workflow needs

## Solution

Added `attestations: write` permission to the `version-and-release.yml` workflow permissions block.

## Testing

- [x] Workflow validation should now pass
- [x] No breaking changes to existing functionality
- [x] Maintains security by only adding the minimal required permission

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow permissions to include attestations write access, improving supply chain integrity and provenance tracking for published artifacts.
  * No changes to application features, behavior, or release process steps.
  * End users and administrators do not need to take any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->