### PR TITLE
fix: prevent incorrect tag creation in release workflows

### DIFF
--- a/.changeset/fix-release-tag-validation.md
+++ b/.changeset/fix-release-tag-validation.md
@@ -1,0 +1,9 @@
+---
+"scopes": patch
+---
+
+Fix release workflow to prevent incorrect tag creation
+
+- Fixed Version and Release workflow to only create tags when Version PR is merged
+- Added tag format validation to Release workflow to prevent branch names being used as tags
+- Improved error messages to guide users on correct tag format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,42 @@ jobs:
           
           echo "Validating tag: $TAG"
           
-          # Ensure tag follows semantic versioning pattern
-          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+          # Ensure tag follows semantic versioning pattern (SemVer 2.0.0 compliant)
+          # Pattern explanation:
+          # ^v                                           - Must start with 'v'
+          # (0|[1-9][0-9]*)                             - Major version (no leading zeros except for 0)
+          # \.(0|[1-9][0-9]*)                           - Minor version (no leading zeros except for 0)
+          # \.(0|[1-9][0-9]*)                           - Patch version (no leading zeros except for 0)
+          # (-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*) - Pre-release version
+          # (\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))? - Additional pre-release identifiers
+          # (\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?     - Build metadata (optional)
+          # $                                           - End of string
+          
+          # Full SemVer 2.0.0 regex pattern
+          SEMVER_PATTERN='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
+          
+          if ! [[ "$TAG" =~ $SEMVER_PATTERN ]]; then
             echo "Error: Invalid tag format '$TAG'"
-            echo "Tag must follow semantic versioning: v1.0.0 or v1.0.0-alpha"
+            echo ""
+            echo "Tag must follow Semantic Versioning 2.0.0 specification:"
+            echo "  Basic format:     vMAJOR.MINOR.PATCH"
+            echo "  Pre-release:      vMAJOR.MINOR.PATCH-PRERELEASE"
+            echo "  Build metadata:   vMAJOR.MINOR.PATCH+BUILD"
+            echo "  Full format:      vMAJOR.MINOR.PATCH-PRERELEASE+BUILD"
+            echo ""
+            echo "Examples:"
+            echo "  v1.0.0"
+            echo "  v2.1.3-alpha"
+            echo "  v1.0.0-alpha.1"
+            echo "  v1.0.0-0.3.7"
+            echo "  v1.0.0-x.7.z.92"
+            echo "  v1.0.0+20130313144700"
+            echo "  v1.0.0-beta+exp.sha.5114f85"
+            echo ""
+            echo "Rules:"
+            echo "  - No leading zeros in numeric versions (except for 0 itself)"
+            echo "  - Pre-release identifiers: alphanumeric and hyphens [0-9A-Za-z-]"
+            echo "  - Pre-release versions have lower precedence than normal versions"
             
             # Check if this might be a branch name
             if [[ "$TAG" == "main" || "$TAG" == "master" || "$TAG" == "develop" || "$TAG" =~ ^(feature|fix|release|hotfix)/ ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,32 @@ env:
   QUARKUS_BUILDER_IMAGE_LINUX_ARM64: "ghcr.io/graalvm/graalvm-ce:ol8-java11-22.3.3@sha256:1622fe4beeb753c07e9196d9ab68755f42d661872a1e9b548b549d6e60194477"
 
 jobs:
+  resolve-version:
+    name: Resolve Version Information
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag_version: ${{ steps.version.outputs.tag_version }}
+    steps:
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="${{ github.ref_name }}"
+          fi
+          # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
+          CLEAN_VERSION=${VERSION#v}
+          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+
   validate-tag:
     name: Validate Release Tag
     runs-on: ubuntu-latest
+    needs: resolve-version
     steps:
       - name: Validate tag format
         shell: bash
@@ -33,11 +56,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          else
-            TAG="${{ github.ref_name }}"
-          fi
+          TAG="${{ needs.resolve-version.outputs.tag_version }}"
           
           echo "Validating tag: $TAG"
           
@@ -115,7 +134,7 @@ jobs:
 
   build-release:
     name: Build Release Artifacts
-    needs: validate-tag
+    needs: [resolve-version, validate-tag]
     runs-on: ${{ matrix.os }}
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -149,25 +168,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Extract version from tag
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          else
-            VERSION="${{ github.ref_name }}"
-          fi
-          # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
-          CLEAN_VERSION=${VERSION#v}
-          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
-          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building version: $CLEAN_VERSION (from tag: $VERSION)"
-
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ steps.version.outputs.tag_version }}
+          ref: ${{ needs.resolve-version.outputs.tag_version }}
 
       - name: Setup QEMU for ARM64 cross-compilation
         if: matrix.platform == 'linux' && matrix.arch == 'arm64'
@@ -195,7 +199,7 @@ jobs:
         if: matrix.platform == 'win32'
         run: |
           Set-Location "C:\build-workspace\scopes"
-          $VERSION_ARG = "-Pversion=${{ steps.version.outputs.version }}"
+          $VERSION_ARG = "-Pversion=${{ needs.resolve-version.outputs.version }}"
 
           # Add architecture-specific flags for ARM64
           $ARCH_FLAGS = ""
@@ -224,16 +228,16 @@ jobs:
           # Disable configuration cache for native build due to GraalVM plugin incompatibility
           # See: https://github.com/kamiazya/scopes/issues/36
           # Run clean build first for reproducible builds
-          ./gradlew --no-daemon --no-configuration-cache --scan clean :apps-scopes:nativeCompile -Pversion="${{ steps.version.outputs.version }}" $ARCH_FLAGS
+          ./gradlew --no-daemon --no-configuration-cache --scan clean :apps-scopes:nativeCompile -Pversion="${{ needs.resolve-version.outputs.version }}" $ARCH_FLAGS
 
       - name: Prepare binary for upload
         shell: bash
         run: |
           if [ "${{ matrix.platform }}" = "win32" ]; then
-            BINARY_NAME="scopes-${{ steps.version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.exe"
+            BINARY_NAME="scopes-${{ needs.resolve-version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.exe"
             cp /c/build-workspace/scopes/apps/scopes/build/native/nativeCompile/scopes.exe "$BINARY_NAME"
           else
-            BINARY_NAME="scopes-${{ steps.version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}"
+            BINARY_NAME="scopes-${{ needs.resolve-version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}"
             cp apps/scopes/build/native/nativeCompile/scopes "$BINARY_NAME"
           fi
           echo "binary_name=$BINARY_NAME" >> $GITHUB_OUTPUT
@@ -243,7 +247,7 @@ jobs:
         if: matrix.platform == 'win32'
         run: |
           Set-Location "C:\build-workspace\scopes"
-          $VERSION_ARG = "-Pversion=${{ steps.version.outputs.version }}"
+          $VERSION_ARG = "-Pversion=${{ needs.resolve-version.outputs.version }}"
           # Disable configuration cache for SBOM generation due to GraalVM plugin incompatibility
           echo "Executing: .\gradlew.bat --no-daemon --no-configuration-cache --scan :apps-scopes:cycloneDxBom $VERSION_ARG"
           & .\gradlew.bat --no-daemon --no-configuration-cache --scan :apps-scopes:cycloneDxBom $VERSION_ARG
@@ -256,7 +260,7 @@ jobs:
         run: |
           # Disable configuration cache for SBOM generation due to GraalVM plugin incompatibility
           # Pass version property to ensure SBOM metadata matches the binaries
-          ./gradlew --no-daemon --no-configuration-cache --scan :apps-scopes:cycloneDxBom -Pversion="${{ steps.version.outputs.version }}"
+          ./gradlew --no-daemon --no-configuration-cache --scan :apps-scopes:cycloneDxBom -Pversion="${{ needs.resolve-version.outputs.version }}"
 
 
       - name: Generate hash for SLSA provenance
@@ -499,7 +503,7 @@ jobs:
   create-unified-package:
     name: Create Unified Distribution Package
     runs-on: ubuntu-latest
-    needs: [validate-tag, build-release, provenance]
+    needs: [resolve-version, validate-tag, build-release, provenance]
     if: always() && needs.build-release.result == 'success'
 
     steps:
@@ -508,24 +512,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Extract version from tag
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          else
-            VERSION="${{ github.ref_name }}"
-          fi
-          # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
-          CLEAN_VERSION=${VERSION#v}
-          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
-          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          ref: ${{ steps.version.outputs.tag_version }}
+          ref: ${{ needs.resolve-version.outputs.tag_version }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -552,7 +542,7 @@ jobs:
 
       - name: Create unified package structure
         run: |
-          PACKAGE_NAME="scopes-${{ steps.version.outputs.version }}-dist"
+          PACKAGE_NAME="scopes-${{ needs.resolve-version.outputs.version }}-dist"
           mkdir -p "${PACKAGE_NAME}"
           cd "${PACKAGE_NAME}"
           
@@ -687,7 +677,7 @@ jobs:
 
       - name: Create distribution package archives
         run: |
-          PACKAGE_NAME="scopes-${{ steps.version.outputs.version }}-dist"
+          PACKAGE_NAME="scopes-${{ needs.resolve-version.outputs.version }}-dist"
           
           # Create tar.gz archive
           tar -czf "${PACKAGE_NAME}.tar.gz" "${PACKAGE_NAME}"
@@ -714,7 +704,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate-tag, build-release, provenance, create-unified-package]
+    needs: [resolve-version, validate-tag, build-release, provenance, create-unified-package]
     if: always() && needs.build-release.result == 'success'
 
     steps:
@@ -726,21 +716,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          ref: ${{ needs.resolve-version.outputs.tag_version }}
           fetch-depth: 0
-
-      - name: Extract version from tag
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          else
-            VERSION="${{ github.ref_name }}"
-          fi
-          # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
-          CLEAN_VERSION=${VERSION#v}
-          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
-          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -781,7 +758,7 @@ jobs:
           ### Quick Verification
           ```bash
           # Download and verify in one command
-          curl -sSL https://raw.githubusercontent.com/kamiazya/scopes/main/install/install.sh | bash
+          curl -sSL https://raw.githubusercontent.com/kamiazya/scopes/${{ needs.resolve-version.outputs.tag_version }}/install/install.sh | bash
           ```
 
           ### Manual Verification
@@ -811,18 +788,18 @@ jobs:
         run: |
           # Generate release notes using GitHub API
           NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
-            -f tag_name='${{ steps.version.outputs.tag_version }}' \
+            -f tag_name='${{ needs.resolve-version.outputs.tag_version }}' \
             --jq .body)
           
           # Create or update release without destructive deletion
-          if ! gh release view "${{ steps.version.outputs.tag_version }}" > /dev/null 2>&1; then
-            gh release create "${{ steps.version.outputs.tag_version }}" \
-              --title "Release ${{ steps.version.outputs.version }}" \
+          if ! gh release view "${{ needs.resolve-version.outputs.tag_version }}" > /dev/null 2>&1; then
+            gh release create "${{ needs.resolve-version.outputs.tag_version }}" \
+              --title "Release ${{ needs.resolve-version.outputs.version }}" \
               --notes "$NOTES" \
               --verify-tag \
-              --prerelease=${{ contains(steps.version.outputs.tag_version, '-') }}
+              --prerelease=${{ contains(needs.resolve-version.outputs.tag_version, '-') }}
           else
-            gh release edit "${{ steps.version.outputs.tag_version }}" --notes "$NOTES"
+            gh release edit "${{ needs.resolve-version.outputs.tag_version }}" --notes "$NOTES"
           fi
 
       - name: Upload release assets
@@ -830,14 +807,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Upload all binary artifacts
-          find artifacts -name "scopes-*" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
+          find artifacts -name "scopes-*" -type f -exec gh release upload "${{ needs.resolve-version.outputs.tag_version }}" --clobber {} \;
 
           # Upload hash files
-          find artifacts -name "binary-hash-*.txt" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
+          find artifacts -name "binary-hash-*.txt" -type f -exec gh release upload "${{ needs.resolve-version.outputs.tag_version }}" --clobber {} \;
 
           # Upload SBOM files
-          find sbom-artifacts -name "sbom-*.json" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
-          find sbom-artifacts -name "sbom-*.xml" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
+          find sbom-artifacts -name "sbom-*.json" -type f -exec gh release upload "${{ needs.resolve-version.outputs.tag_version }}" --clobber {} \;
+          find sbom-artifacts -name "sbom-*.xml" -type f -exec gh release upload "${{ needs.resolve-version.outputs.tag_version }}" --clobber {} \;
 
           # Upload distribution packages
           find distribution-packages -name "scopes-*-dist.tar.gz" -type f -exec gh release upload "${{ steps.version.outputs.tag_version }}" --clobber {} \;
@@ -866,12 +843,12 @@ jobs:
 
           #### Linux/macOS
           ```bash
-          curl -sSL https://raw.githubusercontent.com/kamiazya/scopes/main/install/install.sh | sh
+          curl -sSL https://raw.githubusercontent.com/kamiazya/scopes/${{ steps.version.outputs.tag_version }}/install/install.sh | sh
           ```
 
           #### Windows PowerShell
           ```powershell
-          iwr https://raw.githubusercontent.com/kamiazya/scopes/main/install/install.ps1 | iex
+          iwr https://raw.githubusercontent.com/kamiazya/scopes/${{ steps.version.outputs.tag_version }}/install/install.ps1 | iex
           ```
 
           ### 📦 Offline Installation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           SEMVER_PATTERN='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$'
           
           if ! [[ "$TAG" =~ $SEMVER_PATTERN ]]; then
-            echo "Error: Invalid tag format '$TAG'"
+            echo "::error::Invalid tag format '$TAG'"
             echo ""
             echo "Tag must follow Semantic Versioning 2.0.0 specification:"
             echo "  Basic format:     vMAJOR.MINOR.PATCH"
@@ -86,7 +86,7 @@ jobs:
             # Check if this might be a branch name
             if [[ "$TAG" == "main" || "$TAG" == "master" || "$TAG" == "develop" || "$TAG" =~ ^(feature|fix|release|hotfix)/ ]]; then
               echo ""
-              echo "ERROR: It appears you're trying to create a release with a branch name."
+              echo "::error::It appears you're trying to create a release with a branch name."
               echo "Please use a proper semantic version tag like v1.0.0"
               echo ""
               echo "If using gh workflow run:"
@@ -98,7 +98,25 @@ jobs:
             exit 1
           fi
           
-          echo "✓ Tag format is valid"
+          # For manually triggered runs, ensure the tag exists on the remote
+          # This prevents gh release create from accidentally creating a tag
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
+            echo "Checking if tag exists on remote..."
+            
+            # Use GitHub API to check if tag exists
+            if ! gh api "/repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "::error::Tag '$TAG' does not exist on remote. Please create the tag first."
+              echo ""
+              echo "Tags should be created by the Version and Release workflow when merging Version PRs."
+              echo "If you need to manually create a tag:"
+              echo "  git tag -a $TAG -m \"Release $TAG\""
+              echo "  git push origin $TAG"
+              exit 1
+            fi
+            echo "✓ Tag exists on remote"
+          fi
+          
+          echo "✓ Tag format is valid and tag exists"
 
   build-release:
     name: Build Release Artifacts
@@ -810,6 +828,7 @@ jobs:
             gh release create "${{ steps.version.outputs.tag_version }}" \
               --title "Release ${{ steps.version.outputs.version }}" \
               --notes "$NOTES" \
+              --verify-tag \
               --prerelease=${{ contains(steps.version.outputs.tag_version, '-') }}
           else
             gh release edit "${{ steps.version.outputs.tag_version }}" --notes "$NOTES"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,47 @@ env:
   QUARKUS_BUILDER_IMAGE_LINUX_ARM64: "ghcr.io/graalvm/graalvm-ce:ol8-java11-22.3.3@sha256:1622fe4beeb753c07e9196d9ab68755f42d661872a1e9b548b549d6e60194477"
 
 jobs:
+  validate-tag:
+    name: Validate Release Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag format
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          
+          echo "Validating tag: $TAG"
+          
+          # Ensure tag follows semantic versioning pattern
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "Error: Invalid tag format '$TAG'"
+            echo "Tag must follow semantic versioning: v1.0.0 or v1.0.0-alpha"
+            
+            # Check if this might be a branch name
+            if [[ "$TAG" == "main" || "$TAG" == "master" || "$TAG" == "develop" || "$TAG" =~ ^(feature|fix|release|hotfix)/ ]]; then
+              echo ""
+              echo "ERROR: It appears you're trying to create a release with a branch name."
+              echo "Please use a proper semantic version tag like v1.0.0"
+              echo ""
+              echo "If using gh workflow run:"
+              echo "  gh workflow run release.yml --field tag='v1.0.0'"
+              echo ""
+              echo "If using GitHub API:"
+              echo "  Ensure 'tag_name' is a version tag, not a branch name"
+            fi
+            exit 1
+          fi
+          
+          echo "✓ Tag format is valid"
+
   build-release:
     name: Build Release Artifacts
+    needs: validate-tag
     runs-on: ${{ matrix.os }}
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
@@ -335,7 +374,7 @@ jobs:
   collect-hashes:
     name: Collect Hashes for SLSA
     runs-on: ubuntu-latest
-    needs: build-release
+    needs: [validate-tag, build-release]
     outputs:
       hashes: ${{ steps.collect.outputs.hashes }}
 
@@ -402,7 +441,7 @@ jobs:
 
   provenance:
     name: Generate SLSA Provenance
-    needs: [build-release, collect-hashes]
+    needs: [validate-tag, build-release, collect-hashes]
     permissions:
       actions: read
       id-token: write
@@ -415,7 +454,7 @@ jobs:
   create-unified-package:
     name: Create Unified Distribution Package
     runs-on: ubuntu-latest
-    needs: [build-release, provenance]
+    needs: [validate-tag, build-release, provenance]
     if: always() && needs.build-release.result == 'success'
 
     steps:
@@ -630,7 +669,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-release, provenance, create-unified-package]
+    needs: [validate-tag, build-release, provenance, create-unified-package]
     if: always() && needs.build-release.result == 'success'
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,27 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.tag }}"
+          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
+            VERSION="${{ inputs.tag }}"
+          else
+            VERSION="${{ github.ref_name }}"
+          fi
+          # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
+          CLEAN_VERSION=${VERSION#v}
+          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $CLEAN_VERSION (from tag: $VERSION)"
+
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ steps.version.outputs.tag_version }}
 
       - name: Setup QEMU for ARM64 cross-compilation
         if: matrix.platform == 'linux' && matrix.arch == 'arm64'
@@ -128,23 +147,6 @@ jobs:
         uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           validate-wrappers: true
-
-      - name: Extract version from tag
-        id: version
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
-            VERSION="${{ inputs.tag }}"
-          else
-            VERSION="${{ github.ref_name }}"
-          fi
-          # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
-          CLEAN_VERSION=${VERSION#v}
-          echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
-          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Building version: $CLEAN_VERSION (from tag: $VERSION)"
 
       - name: Build native binary (Windows)
         if: matrix.platform == 'win32'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,9 @@ on:
         description: 'Release tag (e.g., v1.0.0, v2.0.0-alpha)'
         required: true
         type: string
-  workflow_call:
-    inputs:
-      tag:
-        description: 'Release tag (e.g., v1.0.0, v2.0.0-alpha)'
-        required: true
-        type: string
-
 concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
+  group: release-${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -35,10 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate tag format
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
             TAG="${{ inputs.tag }}"
           else
             TAG="${{ github.ref_name }}"
@@ -100,7 +95,7 @@ jobs:
           
           # For manually triggered runs, ensure the tag exists on the remote
           # This prevents gh release create from accidentally creating a tag
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "${{ github.event_name }}" = "workflow_call" ]; then
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Checking if tag exists on remote..."
             
             # Use GitHub API to check if tag exists
@@ -159,8 +154,6 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
             VERSION="${{ inputs.tag }}"
           else
             VERSION="${{ github.ref_name }}"
@@ -515,16 +508,11 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
       - name: Extract version from tag
         id: version
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
             VERSION="${{ inputs.tag }}"
           else
             VERSION="${{ github.ref_name }}"
@@ -533,6 +521,11 @@ jobs:
           CLEAN_VERSION=${VERSION#v}
           echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ steps.version.outputs.tag_version }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -740,8 +733,6 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
             VERSION="${{ inputs.tag }}"
           else
             VERSION="${{ github.ref_name }}"

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -91,12 +91,3 @@ jobs:
           git push origin "$TAG"
           echo "Pushed tag $TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-  run-release:
-    name: Run Release workflow
-    needs: version-and-release
-    if: needs.version-and-release.outputs.tag != ''
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ needs.version-and-release.outputs.tag }}
-    secrets: inherit

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -60,15 +60,52 @@ jobs:
 
       - name: Check if version PR was merged
         id: check_version_pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Check if this push is from a merged Version PR
+          # First, check commit message as a quick filter
           COMMIT_MSG=$(git log -1 --pretty=%B)
-          if [[ "$COMMIT_MSG" == "Release new version" ]]; then
+          if [[ "$COMMIT_MSG" != "Release new version" ]]; then
+            echo "is_version_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a Version PR merge (commit message doesn't match)"
+            exit 0
+          fi
+          
+          # Verify this is actually from a merged PR using GitHub API
+          COMMIT_SHA=${{ github.sha }}
+          echo "Checking if commit $COMMIT_SHA is from a merged PR..."
+          
+          # Search for PRs associated with this commit
+          PR_SEARCH=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/commits/$COMMIT_SHA/pulls" \
+            2>/dev/null || echo "[]")
+          
+          # Check if any PR is a Version PR
+          IS_VERSION_PR=false
+          if [[ "$PR_SEARCH" != "[]" ]]; then
+            # Parse JSON to find merged PRs with title "Release new version"
+            while IFS= read -r pr; do
+              PR_TITLE=$(echo "$pr" | jq -r '.title // ""')
+              PR_MERGED=$(echo "$pr" | jq -r '.merged // false')
+              PR_NUMBER=$(echo "$pr" | jq -r '.number // ""')
+              
+              if [[ "$PR_TITLE" == "Release new version" ]] && [[ "$PR_MERGED" == "true" ]]; then
+                echo "Found merged Version PR #$PR_NUMBER"
+                IS_VERSION_PR=true
+                break
+              fi
+            done < <(echo "$PR_SEARCH" | jq -c '.[]')
+          fi
+          
+          if [[ "$IS_VERSION_PR" == "true" ]]; then
             echo "is_version_release=true" >> "$GITHUB_OUTPUT"
-            echo "Detected merged Version PR"
+            echo "✓ Confirmed: This is a merged Version PR"
           else
             echo "is_version_release=false" >> "$GITHUB_OUTPUT"
-            echo "Not a Version PR merge"
+            echo "⚠️ Warning: Commit has version message but no associated Version PR found"
           fi
 
       - name: Create and push SemVer tag (vX.Y.Z)

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -66,9 +66,10 @@ jobs:
           # Check if this push is from a merged Version PR
           # First, check commit message as a quick filter
           COMMIT_MSG=$(git log -1 --pretty=%B)
-          if [[ "$COMMIT_MSG" != "Release new version" ]]; then
+          # GitHub may append PR number, so use pattern match instead of exact match
+          if [[ ! "$COMMIT_MSG" =~ ^Release\ new\ version ]]; then
             echo "is_version_release=false" >> "$GITHUB_OUTPUT"
-            echo "Not a Version PR merge (commit message doesn't match)"
+            echo "Not a Version PR merge (commit message doesn't match pattern)"
             exit 0
           fi
           

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -58,9 +58,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if version PR was merged
+        id: check_version_pr
+        run: |
+          # Check if this push is from a merged Version PR
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if [[ "$COMMIT_MSG" == "Release new version" ]]; then
+            echo "is_version_release=true" >> "$GITHUB_OUTPUT"
+            echo "Detected merged Version PR"
+          else
+            echo "is_version_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a Version PR merge"
+          fi
+
       - name: Create and push SemVer tag (vX.Y.Z)
         id: semver_tag
-        if: steps.changesets.outputs.published == 'true' || steps.changesets.outputs.hasChangesets == 'true'
+        # Only create tag after Version PR is merged (commit message is "Release new version")
+        if: steps.check_version_pr.outputs.is_version_release == 'true'
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -64,12 +64,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Check if this push is from a merged Version PR
-          # First, check commit message as a quick filter
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          # GitHub may append PR number, so use pattern match instead of exact match
-          if [[ ! "$COMMIT_MSG" =~ ^Release\ new\ version ]]; then
+          # Check both subject and body to support different merge strategies
+          COMMIT_SUBJECT=$(git log -1 --pretty=%s)
+          COMMIT_BODY=$(git log -1 --pretty=%b)
+          
+          # Check if either subject starts with "Release new version" or body contains it
+          # This handles both squash merges (subject) and regular merges (body)
+          if [[ "$COMMIT_SUBJECT" =~ ^Release\ new\ version ]] || [[ "$COMMIT_BODY" =~ ^Release\ new\ version ]]; then
+            echo "Found version release commit pattern"
+          else
             echo "is_version_release=false" >> "$GITHUB_OUTPUT"
-            echo "Not a Version PR merge (commit message doesn't match pattern)"
+            echo "Not a Version PR merge (neither subject nor body matches pattern)"
             exit 0
           fi
           

--- a/docs/explanation/automated-release-process.md
+++ b/docs/explanation/automated-release-process.md
@@ -13,7 +13,7 @@ Scopes uses GitHub's native release notes generation combined with custom verifi
 ```mermaid
 graph LR
     %% Triggers
-    Start([🏷️ Tag Push<br/>v*.*.* or<br/>Manual Dispatch]) 
+    Start([🏷️ Tag Push<br/>v*.*.* or<br/>Manual Dispatch<br/>with --verify-tag]) 
     
     %% Main workflow stages
     Start --> Build[🏗️ Build<br/>Multi-Platform<br/>Artifacts]
@@ -233,6 +233,21 @@ The final release notes follow this structure:
 [Detailed SLSA and SBOM verification examples]
 ```
 
+## Workflow Safety Features
+
+### Tag Validation
+The release workflow includes several safety checks:
+- **Tag Existence**: Validates that the tag exists on the remote repository before proceeding
+- **SemVer Compliance**: Enforces strict SemVer 2.0.0 format (e.g., v1.2.3, v1.2.3-rc.1)
+- **Checkout Verification**: Ensures the workflow builds from the exact tagged commit
+- **Release Verification**: Uses `--verify-tag` flag when creating GitHub releases
+
+### Version PR Detection
+The version-and-release workflow:
+- Uses GitHub API to verify commits are from merged Version PRs
+- Supports both squash merge and regular merge strategies
+- Only creates tags after successful Version PR verification
+
 ## For Maintainers
 
 ### Labeling Pull Requests
@@ -248,17 +263,30 @@ gh pr create --label "docs" --title "Update installation guide"
 
 ### Triggering Releases
 
-Releases are triggered by pushing version tags:
+Releases are now automatically triggered through the Changesets workflow:
 
-```bash
-# Create and push a release tag
-git tag v1.0.0
-git push origin v1.0.0
+1. **Automatic Process** (Recommended):
+   - Create changesets with your PRs
+   - Merge the auto-generated "Release new version" PR
+   - CI automatically creates and pushes the version tag
+   - Release workflow triggers on the new tag
 
-# Or for pre-releases
-git tag v1.0.0-beta.1
-git push origin v1.0.0-beta.1
-```
+2. **Manual Process** (If needed):
+   ```bash
+   # Create and push a release tag manually
+   git tag v1.0.0
+   git push origin v1.0.0
+   
+   # Or for pre-releases
+   git tag v1.0.0-beta.1
+   git push origin v1.0.0-beta.1
+   ```
+
+3. **Manual Workflow Dispatch**:
+   ```bash
+   # Trigger release for existing tag
+   gh workflow run release.yml --field tag=v1.0.0
+   ```
 
 ### Excluding Content
 

--- a/docs/guides/development/changeset-workflow.md
+++ b/docs/guides/development/changeset-workflow.md
@@ -56,7 +56,13 @@ After merging a PR with changesets:
    - Generated `CHANGELOG.md` entries
    - Consumed changeset files are removed
 3. **Version PR Merge**: When this PR is merged, CI creates and pushes a SemVer tag `vX.Y.Z`
-4. **Release Pipeline**: The `Release` workflow triggers on the tag push and builds binaries, SBOM, SLSA, and publishes a GitHub Release
+   - The workflow now uses GitHub API to verify the commit is from a merged Version PR
+   - Supports both squash merge and regular merge strategies
+4. **Release Pipeline**: The `Release` workflow triggers on the tag push and:
+   - Validates the tag exists before proceeding (prevents accidental releases)
+   - Checks out the exact tagged commit for building
+   - Uses `--verify-tag` flag to ensure release integrity
+   - Builds binaries, SBOM, SLSA, and publishes a GitHub Release
 
 ## Available Scripts
 
@@ -120,6 +126,8 @@ Ensure the [Changeset Bot](https://github.com/apps/changeset-bot) is installed o
 - **Trigger**: Push to main branch
 - **Purpose**: Create version PRs; after merge, create and push `vX.Y.Z` tags
 - **Actions**: Uses `changesets/action@v1`
+- **Tag Creation**: Only creates tags after verifying the commit is from a merged Version PR using GitHub API
+- **Safety**: No longer includes direct release job to prevent double execution
 
 ### Release (`.github/workflows/release.yml`)
 - **Trigger**: Tag push (`v*.*.*` and `v*.*.*-*`), or manual `workflow_dispatch`

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "scopes",
-  "version": "0.0.1",
-  "private": true,
-  "scripts": {
-    "changeset": "changeset",
-    "changeset:add": "changeset add",
-    "changeset:status": "changeset status",
-    "version-packages": "changeset version",
-    "tag": "changeset tag"
+  "name" : "scopes",
+  "version" : "0.0.1",
+  "private" : true,
+  "scripts" : {
+    "changeset" : "changeset",
+    "changeset:add" : "changeset add",
+    "changeset:status" : "changeset status",
+    "version-packages" : "changeset version",
+    "tag" : "changeset tag"
   },
-  "author": "Yuki Yamazaki <yuki@kamiazya.tech>",
-  "license": "Apache-2.0",
-  "engines": {
-    "node": ">=24"
+  "author" : "Yuki Yamazaki <yuki@kamiazya.tech>",
+  "license" : "Apache-2.0",
+  "engines" : {
+    "node" : ">=24"
   },
-  "packageManager": "pnpm@10.6.5",
-  "devDependencies": {
-    "@changesets/changelog-github": "^0.5.1",
-    "@changesets/cli": "^2.29.7"
+  "packageManager" : "pnpm@10.6.5",
+  "devDependencies" : {
+    "@changesets/changelog-github" : "^0.5.1",
+    "@changesets/cli" : "^2.29.7"
   }
 }


### PR DESCRIPTION
## Problem

PR #266 created a release with "main" tag instead of intended "v0.0.1" tag. This was due to the release workflow being triggered before the Version PR merge process completed creating the version tag, leading to a fallback to the default branch name.

## Root Cause

The version-and-release workflow had a `run-release` job that could trigger the release workflow before the tag creation step completed, causing a race condition.

## Solution

This PR implements comprehensive fixes based on thorough code review:

### Critical Issues Fixed ✅
1. **Removed `run-release` job** - Eliminated double execution risk by relying only on tag push triggers
2. **Fixed checkout to use tag ref** - Ensures correct commit is built (was checking out default branch)
3. **Enhanced Version PR detection** - Now uses GitHub API to verify commits are from merged Version PRs
4. **Improved tag validation** - Full SemVer 2.0.0 regex compliance

### Additional Improvements from AI Review ✅
5. **Added tag existence verification** - Prevents creating releases for non-existent tags
6. **Improved merge commit support** - Handles both squash and regular merge strategies

### Documentation Updates ✅
7. **Updated release testing guide** - Documents tag creation requirement
8. **Enhanced changeset workflow docs** - Explains new validation steps
9. **Added workflow safety features section** - Documents all validation mechanisms

## Testing

- [x] Tag validation regex tested with various formats
- [x] Version PR detection tested for different merge strategies
- [x] Documentation reviewed for accuracy
- [x] All changes pushed successfully

## Impact

These changes ensure that:
- Version tags are always created correctly before releases
- Release workflow is more robust with proper validation
- Documentation clearly explains the improved process
