### PR TITLE
feat: Add JaCoCo coverage and SonarCloud integration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,79 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+    - name: Harden the runner
+      uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+      with:
+        egress-policy: audit
+
+    - name: Checkout code
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        fetch-depth: 0  # Shallow clones should be disabled for better analysis
+
+    - name: Set up GraalVM
+      uses: graalvm/setup-graalvm@e140024fdc2d95d3c7e10a636887a91090d29990 # v1.4.0
+      with:
+        java-version: '21'
+        distribution: 'graalvm'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+      with:
+        validate-wrappers: true
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+    - name: Run tests with coverage
+      run: ./gradlew --no-daemon test jacocoTestReport
+
+    - name: Generate aggregate coverage report
+      run: ./gradlew --no-daemon :coverage-report:testCodeCoverageReport
+
+    - name: Run Detekt analysis
+      run: ./gradlew --no-daemon detekt
+
+    - name: SonarCloud Scan
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ./gradlew --no-daemon sonarqube --info
+
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      if: always()
+      with:
+        name: coverage-reports
+        path: |
+          **/build/reports/jacoco/
+          coverage-report/build/reports/jacoco/
+        if-no-files-found: warn
+
+    - name: Upload test results
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      if: always()
+      with:
+        name: test-results
+        path: |
+          **/build/test-results/
+          **/build/reports/tests/
+        if-no-files-found: warn

--- a/coverage-report/build.gradle.kts
+++ b/coverage-report/build.gradle.kts
@@ -1,0 +1,73 @@
+plugins {
+    base
+    alias(libs.plugins.jacoco.report.aggregation)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    jacocoAggregation(project(":platform-commons"))
+    jacocoAggregation(project(":platform-application-commons"))
+    jacocoAggregation(project(":platform-domain-commons"))
+    jacocoAggregation(project(":platform-infrastructure"))
+    jacocoAggregation(project(":platform-observability"))
+
+    // Contracts
+    jacocoAggregation(project(":contracts-scope-management"))
+    jacocoAggregation(project(":contracts-user-preferences"))
+    jacocoAggregation(project(":contracts-event-store"))
+    jacocoAggregation(project(":contracts-device-synchronization"))
+
+    // Scope Management Context
+    jacocoAggregation(project(":scope-management-domain"))
+    jacocoAggregation(project(":scope-management-application"))
+    jacocoAggregation(project(":scope-management-infrastructure"))
+
+    // User Preferences Context
+    jacocoAggregation(project(":user-preferences-domain"))
+    jacocoAggregation(project(":user-preferences-application"))
+    jacocoAggregation(project(":user-preferences-infrastructure"))
+
+    // Event Store Context
+    jacocoAggregation(project(":event-store-domain"))
+    jacocoAggregation(project(":event-store-application"))
+    jacocoAggregation(project(":event-store-infrastructure"))
+
+    // Device Synchronization Context
+    jacocoAggregation(project(":device-synchronization-domain"))
+    jacocoAggregation(project(":device-synchronization-application"))
+    jacocoAggregation(project(":device-synchronization-infrastructure"))
+
+    // Interfaces
+    jacocoAggregation(project(":interfaces-cli"))
+    jacocoAggregation(project(":interfaces-mcp"))
+
+    // Apps
+    jacocoAggregation(project(":apps-scopes"))
+    jacocoAggregation(project(":apps-scopesd"))
+
+    // Quality
+    jacocoAggregation(project(":quality-konsist"))
+}
+
+reporting {
+    reports {
+        val testCodeCoverageReport by creating(JacocoCoverageReport::class) {
+            reportTask.configure {
+                classDirectories.setFrom(
+                    files(
+                        subprojects.map { project ->
+                            project.fileTree("build/classes/kotlin/main")
+                        },
+                    ),
+                )
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.named("testCodeCoverageReport"))
+}

--- a/docs/guides/coverage-and-sonarcloud.md
+++ b/docs/guides/coverage-and-sonarcloud.md
@@ -1,0 +1,157 @@
+# Code Coverage and SonarCloud Integration
+
+This guide explains how to use JaCoCo code coverage and SonarCloud quality analysis in the Scopes project.
+
+## Overview
+
+The project uses:
+- **JaCoCo** for code coverage measurement
+- **JaCoCo Report Aggregation** for multi-module coverage consolidation
+- **SonarCloud** for continuous code quality and security analysis
+
+## Local Development
+
+### Running Tests with Coverage
+
+To run all tests and generate coverage reports:
+
+```bash
+# Run tests with individual module coverage
+./gradlew test jacocoTestReport
+
+# Run tests and generate aggregated coverage report
+./gradlew testWithCoverage
+
+# View aggregated HTML report
+open coverage-report/build/reports/jacoco/testCodeCoverageReport/html/index.html
+```
+
+### Running SonarQube Analysis Locally
+
+To run a complete analysis with coverage:
+
+```bash
+# Set your SonarCloud token (get from https://sonarcloud.io/account/security)
+export SONAR_TOKEN=your_token_here
+
+# Run full analysis
+./gradlew sonarqubeWithCoverage
+```
+
+This will:
+1. Run all tests
+2. Generate JaCoCo coverage reports
+3. Run Detekt static analysis
+4. Upload results to SonarCloud
+
+## Coverage Reports
+
+### Individual Module Reports
+
+Each module generates its own coverage report:
+- Location: `{module}/build/reports/jacoco/test/html/index.html`
+- Format: HTML, XML
+
+### Aggregated Report
+
+The `coverage-report` module aggregates coverage from all modules:
+- Location: `coverage-report/build/reports/jacoco/testCodeCoverageReport/`
+- Formats:
+  - HTML: `html/index.html`
+  - XML: `testCodeCoverageReport.xml` (used by SonarCloud)
+
+## CI/CD Integration
+
+### GitHub Actions Workflow
+
+The project includes a dedicated SonarCloud workflow (`.github/workflows/sonarcloud.yml`) that:
+1. Runs on every push to main and pull request
+2. Executes tests with coverage
+3. Generates aggregated reports
+4. Uploads results to SonarCloud
+
+### Required Secrets
+
+Configure these in GitHub repository settings:
+- `SONAR_TOKEN`: Your SonarCloud authentication token
+  - Get from: https://sonarcloud.io/account/security
+  - Add in: Settings → Secrets → Actions
+
+## SonarCloud Configuration
+
+### Project Setup
+
+1. Go to https://sonarcloud.io
+2. Import your GitHub repository
+3. Configure analysis method as "GitHub Actions"
+4. Note your project key and organization
+
+### Quality Gates
+
+SonarCloud enforces quality gates for:
+- Code coverage (default: 60% minimum)
+- Code duplication
+- Security vulnerabilities
+- Code smells
+- Bugs
+
+### Viewing Results
+
+Access your project dashboard at:
+```
+https://sonarcloud.io/project/overview?id=kamiazya_scopes
+```
+
+## Coverage Exclusions
+
+The following are excluded from coverage:
+- Test files (`*Test.kt`, `*Spec.kt`)
+- Generated code (`**/generated/**`)
+- Build directories (`**/build/**`)
+
+## Gradle Tasks Reference
+
+| Task | Description |
+|------|-------------|
+| `test` | Run unit tests |
+| `jacocoTestReport` | Generate coverage report for a module |
+| `testWithCoverage` | Run all tests and generate all coverage reports |
+| `:coverage-report:testCodeCoverageReport` | Generate aggregated coverage report |
+| `sonarqube` | Run SonarQube analysis |
+| `sonarqubeWithCoverage` | Complete analysis with coverage |
+
+## Troubleshooting
+
+### No Coverage Data
+
+If coverage shows 0%:
+1. Ensure tests are actually running: `./gradlew test --info`
+2. Check JaCoCo data files exist: `find . -name "*.exec"`
+3. Verify test task configuration includes JaCoCo
+
+### SonarCloud Authentication Failed
+
+1. Verify token is set: `echo $SONAR_TOKEN`
+2. Check token permissions in SonarCloud
+3. Ensure token is not expired
+
+### Module Not Included in Coverage
+
+1. Check module is listed in `coverage-report/build.gradle.kts`
+2. Verify module has Kotlin plugin applied
+3. Ensure module has tests that execute
+
+## Best Practices
+
+1. **Run coverage locally** before pushing to verify changes
+2. **Monitor trends** in SonarCloud rather than absolute values
+3. **Fix critical issues** identified by SonarCloud promptly
+4. **Exclude generated code** from analysis to avoid noise
+5. **Write meaningful tests** that actually exercise code paths
+
+## Additional Resources
+
+- [JaCoCo Documentation](https://www.jacoco.org/jacoco/trunk/doc/)
+- [SonarCloud Documentation](https://docs.sonarcloud.io/)
+- [Gradle JaCoCo Plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html)
+- [SonarQube Gradle Plugin](https://docs.sonarqube.org/latest/analyzing-source-code/scanners/sonarscanner-for-gradle/)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,10 @@ ktlint-tool = "1.5.0"
 # Security patches
 netty-codec-http2 = "4.2.6.Final"
 
+# Testing and coverage
+jacoco = "0.8.12"
+sonarqube = "6.0.1.5171"
+
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
@@ -92,6 +96,8 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedx-bom" }
 spdx-sbom = { id = "org.spdx.sbom", version.ref = "spdx-sbom" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+jacoco-report-aggregation = { id = "jacoco-report-aggregation" }
 
 [bundles]
 kotest = ["kotest-runner-junit5", "kotest-assertions-core", "kotest-assertions-arrow", "kotest-property"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,6 +48,8 @@ include(
     ":interfaces-mcp",
     // Quality
     ":quality-konsist",
+    // Coverage aggregation
+    ":coverage-report",
 )
 
 // Configure Gradle Build Scan

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,47 @@
+# SonarCloud Project Configuration
+sonar.projectKey=kamiazya_scopes
+sonar.organization=kamiazya
+sonar.host.url=https://sonarcloud.io
+
+# Project Information
+sonar.projectName=Scopes
+sonar.projectVersion=${version}
+
+# Source Information
+sonar.sources=.
+sonar.inclusions=**/*.kt,**/*.kts
+sonar.exclusions=**/build/**,**/test/**,**/*Test.kt,**/*Spec.kt,**/generated/**,**/node_modules/**
+
+# Test Information
+sonar.tests=.
+sonar.test.inclusions=**/*Test.kt,**/*Spec.kt,**/test/**/*.kt
+
+# Language Settings
+sonar.language=kotlin
+sonar.kotlin.detekt.reportPaths=build/reports/detekt/detekt.xml
+
+# Coverage Settings
+sonar.coverage.jacoco.xmlReportPaths=coverage-report/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+
+# Encoding
+sonar.sourceEncoding=UTF-8
+
+# Duplication Detection
+sonar.cpd.exclusions=**/*Test.kt,**/*Spec.kt
+
+# Issue Exclusions (for generated/vendor code)
+sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria.e1.ruleKey=kotlin:S125
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/generated/**
+sonar.issue.ignore.multicriteria.e2.ruleKey=*
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/vendor/**
+
+# Module-specific settings
+sonar.modules=platform-commons,platform-observability,platform-application-commons,\
+platform-domain-commons,platform-infrastructure,interfaces-cli,interfaces-mcp,\
+contracts-scope-management,contracts-user-preferences,contracts-event-store,\
+contracts-device-synchronization,scope-management-domain,scope-management-application,\
+scope-management-infrastructure,user-preferences-domain,user-preferences-application,\
+user-preferences-infrastructure,event-store-domain,event-store-application,\
+event-store-infrastructure,device-synchronization-domain,device-synchronization-application,\
+device-synchronization-infrastructure,apps-scopes,apps-scopesd,quality-konsist


### PR DESCRIPTION
## Summary

This PR adds comprehensive code coverage tracking and quality analysis through JaCoCo and SonarCloud integration.

## Changes

### 🎯 JaCoCo Coverage Configuration
- Added JaCoCo plugin to all Kotlin modules for coverage measurement
- Created `coverage-report` module for multi-module coverage aggregation
- Configured XML reports for SonarCloud consumption
- Set 60% minimum coverage threshold

### ☁️ SonarCloud Integration
- Integrated SonarQube Gradle plugin v6.0.1.5171
- Added `sonar-project.properties` configuration
- Created dedicated GitHub Actions workflow
- Configured aggregated coverage reporting

### 📚 Documentation
- Added comprehensive guide at `docs/guides/coverage-and-sonarcloud.md`
- Included local development instructions
- Documented CI/CD integration steps
- Added troubleshooting section

## New Gradle Tasks

| Task | Description |
|------|-------------|
| `testWithCoverage` | Run all tests and generate coverage reports |
| `sonarqubeWithCoverage` | Complete analysis with coverage and quality reports |
| `:coverage-report:testCodeCoverageReport` | Generate aggregated coverage report |

## Testing

To test locally:
```bash
# Run tests with coverage
./gradlew testWithCoverage

# View aggregated HTML report
open coverage-report/build/reports/jacoco/testCodeCoverageReport/html/index.html
```

## Setup Required

After merging, configure the following:

1. **SonarCloud Account**:
   - Import repository at https://sonarcloud.io
   - Project key is already configured as `kamiazya_scopes`

2. **GitHub Secret**:
   - Generate token at https://sonarcloud.io/account/security
   - Add as `SONAR_TOKEN` in repository settings

## Benefits

- 📊 **Continuous Coverage Monitoring**: Track test coverage trends over time
- 🐛 **Quality Gates**: Automatic quality checks on every PR
- 🔍 **Code Analysis**: Detect bugs, vulnerabilities, and code smells
- 📈 **Multi-Module Support**: Aggregated coverage across all 26+ modules

## Files Changed

- `build.gradle.kts` - JaCoCo and SonarQube plugin configuration
- `gradle/libs.versions.toml` - Added plugin versions
- `settings.gradle.kts` - Added coverage-report module
- `coverage-report/build.gradle.kts` - Coverage aggregation configuration
- `.github/workflows/sonarcloud.yml` - CI/CD workflow
- `sonar-project.properties` - SonarCloud project settings
- `docs/guides/coverage-and-sonarcloud.md` - Documentation

🤖 Generated with [Claude Code](https://claude.ai/code)