### PR TITLE
fix: update version-and-release workflow to handle GitHub API changes

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -95,7 +95,7 @@ jobs:
             # Parse JSON to find merged PRs with title "Release new version"
             while IFS= read -r pr; do
               PR_TITLE=$(echo "$pr" | jq -r '.title // ""')
-              PR_MERGED=$(echo "$pr" | jq -r '.merged // false')
+              PR_MERGED=$(echo "$pr" | jq -r 'if .merged_at != null then "true" else "false" end')
               PR_NUMBER=$(echo "$pr" | jq -r '.number // ""')
               
               if [[ "$PR_TITLE" == "Release new version" ]] && [[ "$PR_MERGED" == "true" ]]; then


### PR DESCRIPTION
## Summary

The version-and-release workflow was failing to create tags after Version PRs were merged due to a change in the GitHub API response format.

## Problem
- The workflow was checking for a `merged` field that no longer exists in the GitHub API response
- This caused PR #269 (v0.0.2) to be merged without creating the corresponding release tag

## Solution
- Updated the workflow to check the `merged_at` field instead
- This field is `null` for unmerged PRs and contains a timestamp for merged PRs

## Testing
- Manually created v0.0.2 tag to resolve the immediate issue
- This fix will prevent the same problem from occurring in future releases

Fixes the issue where release tags were not being created automatically after merging Version PRs created by Changesets.