### PR TITLE
fix: integrate release workflow to avoid GitHub Actions limitations

### DIFF
--- a/.changeset/fix-release-workflow-integration.md
+++ b/.changeset/fix-release-workflow-integration.md
@@ -8,4 +8,5 @@ Fix automatic release workflow triggering after Version PR merges
 - GitHub Actions security prevents workflows from triggering other workflows when using GITHUB_TOKEN
 - Modified release.yml to only support manual workflow_dispatch
 - Updated permissions to `actions: write` to allow workflow dispatch via gh CLI
+- Fixed gh CLI authentication by using GH_TOKEN environment variable instead of GITHUB_TOKEN
 - Automatic releases now work correctly after Version PR merges without requiring Personal Access Tokens

--- a/.changeset/fix-release-workflow-integration.md
+++ b/.changeset/fix-release-workflow-integration.md
@@ -1,0 +1,10 @@
+---
+"scopes": patch
+---
+
+Fix automatic release workflow triggering after Version PR merges
+
+- Integrated release triggering into version-and-release.yml to work around GitHub Actions limitations
+- GitHub Actions security prevents workflows from triggering other workflows when using GITHUB_TOKEN
+- Modified release.yml to only support manual workflow_dispatch
+- Automatic releases now work correctly after Version PR merges without requiring Personal Access Tokens

--- a/.changeset/fix-release-workflow-integration.md
+++ b/.changeset/fix-release-workflow-integration.md
@@ -7,4 +7,5 @@ Fix automatic release workflow triggering after Version PR merges
 - Integrated release triggering into version-and-release.yml to work around GitHub Actions limitations
 - GitHub Actions security prevents workflows from triggering other workflows when using GITHUB_TOKEN
 - Modified release.yml to only support manual workflow_dispatch
+- Updated permissions to `actions: write` to allow workflow dispatch via gh CLI
 - Automatic releases now work correctly after Version PR merges without requiring Personal Access Tokens

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags: ['v*.*.*', 'v*.*.*-*']
   workflow_dispatch:
     inputs:
       tag:
@@ -10,7 +8,7 @@ on:
         required: true
         type: string
 concurrency:
-  group: release-${{ github.event_name == 'push' && github.ref_name || inputs.tag }}
+  group: release-${{ inputs.tag }}
   cancel-in-progress: true
 
 permissions:
@@ -35,11 +33,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.tag }}"
-          else
-            VERSION="${{ github.ref_name }}"
-          fi
+          VERSION="${{ inputs.tag }}"
           # Remove 'v' prefix for SemVer compatibility (v1.0.0 -> 1.0.0)
           CLEAN_VERSION=${VERSION#v}
           echo "version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
@@ -114,21 +108,19 @@ jobs:
           
           # For manually triggered runs, ensure the tag exists on the remote
           # This prevents gh release create from accidentally creating a tag
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Checking if tag exists on remote..."
-            
-            # Use GitHub API to check if tag exists
-            if ! gh api "/repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
-              echo "::error::Tag '$TAG' does not exist on remote. Please create the tag first."
-              echo ""
-              echo "Tags should be created by the Version and Release workflow when merging Version PRs."
-              echo "If you need to manually create a tag:"
-              echo "  git tag -a $TAG -m \"Release $TAG\""
-              echo "  git push origin $TAG"
-              exit 1
-            fi
-            echo "✓ Tag exists on remote"
+          echo "Checking if tag exists on remote..."
+          
+          # Use GitHub API to check if tag exists
+          if ! gh api "/repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag '$TAG' does not exist on remote. Please create the tag first."
+            echo ""
+            echo "Tags should be created by the Version and Release workflow when merging Version PRs."
+            echo "If you need to manually create a tag:"
+            echo "  git tag -a $TAG -m \"Release $TAG\""
+            echo "  git push origin $TAG"
+            exit 1
           fi
+          echo "✓ Tag exists on remote"
           
           echo "✓ Tag format is valid and tag exists"
 

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -156,7 +156,7 @@ jobs:
       
       - name: Trigger Release Workflow
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Triggering release workflow for tag: ${{ needs.version-and-release.outputs.tag }}"
           gh workflow run release.yml \

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -126,6 +126,9 @@ jobs:
           git fetch --tags --quiet
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists. Skipping creation."
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -134,3 +137,28 @@ jobs:
           git push origin "$TAG"
           echo "Pushed tag $TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+
+  # Trigger release workflow if tag was created or already exists
+  release:
+    name: Trigger Release
+    runs-on: ubuntu-latest
+    needs: version-and-release
+    if: needs.version-and-release.outputs.tag != ''
+    steps:
+      - name: Checkout for gh CLI
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: |
+            .github
+          sparse-checkout-cone-mode: false
+      
+      - name: Trigger Release Workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering release workflow for tag: ${{ needs.version-and-release.outputs.tag }}"
+          gh workflow run release.yml \
+            --repo ${{ github.repository }} \
+            --field tag="${{ needs.version-and-release.outputs.tag }}"

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
-  actions: read
+  actions: write  # Changed from 'read' to 'write' to allow workflow dispatch
   attestations: write
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
   Updated to check 'merged_at' field instead to properly detect merged Version PRs.
 
   This fixes the issue where release tags were not being created automatically after merging Version PRs.
-  EOF < /dev/null
 
 ## 0.0.2
 


### PR DESCRIPTION
## Problem
After merging PR #272 and #271, the v0.0.3 tag was created but the Release workflow was not triggered. This is due to a GitHub Actions security limitation where workflows triggered by GITHUB_TOKEN cannot trigger other workflows.

## Root Cause
- GitHub Actions prevents workflows from triggering other workflows when using GITHUB_TOKEN (to prevent infinite loops)
- The version-and-release.yml workflow creates and pushes tags using GITHUB_TOKEN
- These tag pushes don't trigger the release.yml workflow

## Solution
Integrated the release triggering into the version-and-release workflow:

1. **Modified version-and-release.yml**:
   - Added a new job that triggers the release workflow after tag creation
   - Uses `gh workflow run` to manually trigger the release workflow

2. **Modified release.yml**:
   - Removed the tag push trigger (since it doesn't work with GITHUB_TOKEN)
   - Now only supports manual workflow_dispatch
   - This ensures the workflow can still be triggered manually if needed

## Benefits
- Automatic releases work again after Version PR merges
- No need for Personal Access Tokens (PAT)
- Simpler and more maintainable solution
- Manual release capability preserved

## Testing
The changes will be tested on the next Version PR merge. The workflow will:
1. Create a tag when a Version PR is merged
2. Automatically trigger the release workflow
3. Build and publish the release artifacts

## Related Issues
- Fixes the issue where releases were not being created automatically
- Follows up on #272 which fixed the Version PR detection

/cc @kamiazya

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic release triggers now run immediately after versioning completes without manual intervention.
- Bug Fixes
  - More reliable tag detection and validation to prevent release failures.
- Chores
  - Simplified release workflow: manual dispatch enabled, standardized concurrency, and consistent tag-based execution.
  - Added a dedicated step to trigger the release process from the versioning workflow.
- Documentation
  - Updated changelog to reflect release workflow improvements and successful automatic releases after Version PR merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->