### PR TITLE
security: fix Dependabot vulnerabilities by updating dependencies

### DIFF
--- a/.changeset/security-fix-dependabot-vulnerabilities.md
+++ b/.changeset/security-fix-dependabot-vulnerabilities.md
@@ -4,7 +4,7 @@
 
 Fix medium and low severity security vulnerabilities in dependencies
 
-- Update Apache Commons Lang3 to 3.18.0 to fix CVE-2025-48924 (uncontrolled recursion vulnerability)
+- Update Apache Commons Lang3 to 3.18.0 to fix an uncontrolled recursion vulnerability
 - Verify Logback 1.5.18 includes fixes for CVE-2024-12801 (SSRF) and CVE-2024-12798 (Expression Language injection)
 - Add explicit commons-lang3 dependency to ensure secure version is used across all modules
 

--- a/.changeset/security-fix-dependabot-vulnerabilities.md
+++ b/.changeset/security-fix-dependabot-vulnerabilities.md
@@ -2,7 +2,7 @@
 "scopes": patch
 ---
 
-Fix critical security vulnerabilities in dependencies
+Fix medium and low severity security vulnerabilities in dependencies
 
 - Update Apache Commons Lang3 to 3.18.0 to fix CVE-2025-48924 (uncontrolled recursion vulnerability)
 - Verify Logback 1.5.18 includes fixes for CVE-2024-12801 (SSRF) and CVE-2024-12798 (Expression Language injection)

--- a/.changeset/security-fix-dependabot-vulnerabilities.md
+++ b/.changeset/security-fix-dependabot-vulnerabilities.md
@@ -1,0 +1,11 @@
+---
+"scopes": patch
+---
+
+Fix critical security vulnerabilities in dependencies
+
+- Update Apache Commons Lang3 to 3.18.0 to fix CVE-2025-48924 (uncontrolled recursion vulnerability)
+- Verify Logback 1.5.18 includes fixes for CVE-2024-12801 (SSRF) and CVE-2024-12798 (Expression Language injection)
+- Add explicit commons-lang3 dependency to ensure secure version is used across all modules
+
+This patch resolves all 3 open Dependabot security alerts (2 medium severity, 1 low severity) without breaking changes to the public API.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ sqldelight = "2.1.0"
 # Logging
 slf4j = "2.0.17"
 logback = "1.5.18"
+commons-lang3 = "3.18.0"
 
 graalvm-buildtools = "0.11.0"
 graalvm-sdk = "25.0.0"
@@ -79,6 +80,7 @@ kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.re
 kotlinx-io-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-io-core-jvm", version.ref = "kotlinx-io" }
 
 # Security patches
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty-codec-http2" }
 
 [plugins]

--- a/package.json
+++ b/package.json
@@ -1,22 +1,22 @@
 {
-  "name": "scopes",
-  "version": "0.0.3",
-  "private": true,
-  "scripts": {
-    "changeset": "changeset",
-    "changeset:add": "changeset add",
-    "changeset:status": "changeset status",
-    "version-packages": "changeset version",
-    "tag": "changeset tag"
+  "name" : "scopes",
+  "version" : "0.0.3",
+  "private" : true,
+  "scripts" : {
+    "changeset" : "changeset",
+    "changeset:add" : "changeset add",
+    "changeset:status" : "changeset status",
+    "version-packages" : "changeset version",
+    "tag" : "changeset tag"
   },
-  "author": "Yuki Yamazaki <yuki@kamiazya.tech>",
-  "license": "Apache-2.0",
-  "engines": {
-    "node": ">=24"
+  "author" : "Yuki Yamazaki <yuki@kamiazya.tech>",
+  "license" : "Apache-2.0",
+  "engines" : {
+    "node" : ">=24"
   },
-  "packageManager": "pnpm@10.6.5",
-  "devDependencies": {
-    "@changesets/changelog-github": "^0.5.1",
-    "@changesets/cli": "^2.29.7"
+  "packageManager" : "pnpm@10.6.5",
+  "devDependencies" : {
+    "@changesets/changelog-github" : "^0.5.1",
+    "@changesets/cli" : "^2.29.7"
   }
 }

--- a/platform/infrastructure/build.gradle.kts
+++ b/platform/infrastructure/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.coroutines.core)
 
+    // Security patches
+    api(libs.commons.lang3)
+
     // Dependency injection
     implementation(platform(libs.koin.bom))
     implementation(libs.koin.core)


### PR DESCRIPTION
## Summary
Fixes three open Dependabot security vulnerabilities by updating vulnerable dependencies to secure versions.

## Security Fixes

### 🔴 CVE-2025-48924 - Apache Commons Lang Uncontrolled Recursion (Medium Severity)
- **Alert**: [Dependabot #3](https://github.com/kamiazya/scopes/security/dependabot/3)
- **Fix**: Update Apache Commons Lang3 from vulnerable versions to **3.18.0**
- **Impact**: Prevents StackOverflowError on very long inputs to ClassUtils.getClass()

### 🟡 CVE-2024-12801 - Logback SSRF (Low Severity)
- **Alert**: [Dependabot #2](https://github.com/kamiazya/scopes/security/dependabot/2)
- **Fix**: Current Logback 1.5.18 already includes fix (required ≥ 1.5.13)
- **Impact**: Prevents server-side request forgery via compromised XML configuration

### 🟡 CVE-2024-12798 - Logback Expression Language Injection (Medium Severity)
- **Alert**: [Dependabot #1](https://github.com/kamiazya/scopes/security/dependabot/1)
- **Fix**: Current Logback 1.5.18 already includes fix (required ≥ 1.5.13)
- **Impact**: Prevents arbitrary code execution via malicious configuration

## Changes
- Added explicit `commons-lang3:3.18.0` dependency to `platform-infrastructure`
- Updated version catalog with secure commons-lang3 version
- Verified current Logback 1.5.18 meets security requirements
- Added changeset for patch-level security update

## Verification
✅ All builds pass with updated dependencies  
✅ Dependencies verified:
- `ch.qos.logback:logback-classic:1.5.18` (secure)
- `org.apache.commons:commons-lang3:3.18.0` (secure)

🤖 Generated with [Claude Code](https://claude.ai/code)